### PR TITLE
Remove defaults for DB env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-"""# Variáveis de ambiente para a conexão com o MySQL
+# Variáveis de ambiente para a conexão com o MySQL
 DB_HOST=
 DB_USER=
 DB_PASSWORD=
@@ -9,4 +9,3 @@ SQLALCHEMY_DATABASE_URI=
 
 # Chave secreta para proteger sessões e CSRF no Flask
 SECRET_KEY=
-"""

--- a/database.py
+++ b/database.py
@@ -22,11 +22,28 @@ class DatabaseManager:
     def connect(self):
         """Estabelece conexão com o banco de dados"""
         try:
+            host = os.getenv('DB_HOST')
+            database = os.getenv('DB_NAME')
+            user = os.getenv('DB_USER')
+            password = os.getenv('DB_PASSWORD')
+
+            missing = [k for k, v in {
+                'DB_HOST': host,
+                'DB_NAME': database,
+                'DB_USER': user,
+                'DB_PASSWORD': password
+            }.items() if not v]
+
+            if missing:
+                raise EnvironmentError(
+                    f"Missing required environment variables: {', '.join(missing)}"
+                )
+
             self.connection = mysql.connector.connect(
-                host=os.getenv('DB_HOST', 'localhost'),
-                database=os.getenv('DB_NAME', 'cadastro_empresas'),
-                user=os.getenv('DB_USER', 'root'),
-                password=os.getenv('DB_PASSWORD', 'ti02@2025'),
+                host=host,
+                database=database,
+                user=user,
+                password=password,
                 autocommit=False
             )
             self.cursor = self.connection.cursor(dictionary=True)


### PR DESCRIPTION
## Summary
- read DB connection settings only from environment variables
- add error when required variables are missing
- fix `.env.example` formatting

## Testing
- `pytest -q`
- `python -m py_compile database.py`
- `python -m py_compile app/__init__.py`


------
https://chatgpt.com/codex/tasks/task_b_685c4b0d6ba8832ab1d2ee50fa47f166

## Summary by Sourcery

Enforce explicit database configuration by removing default DB env var fallbacks and requiring DB_HOST, DB_NAME, DB_USER, and DB_PASSWORD to be set, raising an error if any are missing; update .env.example formatting.

Enhancements:
- Require all database environment variables to be set and raise an error if any are missing
- Remove default fallback values for database connection settings

Documentation:
- Fix formatting in .env.example