### PR TITLE
Add departamento pessoal form

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, RadioField, SubmitField, DateField, SelectMultipleField, SelectField
+from wtforms import StringField, RadioField, SubmitField, DateField, SelectMultipleField, SelectField, TextAreaField, PasswordField, MultipleFileField
 from wtforms.validators import DataRequired, Email
 
 class EmpresaForm(FlaskForm):
@@ -42,3 +42,105 @@ class EditUserForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(), Email()])
     name = StringField('Nome', validators=[DataRequired()])
     role = SelectField('Perfil', choices=[('user', 'Usuário'), ('admin', 'Administrador')], validators=[DataRequired()])
+
+
+class DepartamentoForm(FlaskForm):
+    responsavel = StringField('Responsável', validators=[DataRequired()])
+    descricao = StringField('Descrição')
+    submit = SubmitField('Cadastrar')
+
+
+class DepartamentoFiscalForm(DepartamentoForm):
+    formas_importacao = SelectMultipleField('Formas de Importação', choices=[
+        ('entradas_sped', 'Entradas por Sped'),
+        ('entradas_xml', 'Entradas por XML'),
+        ('entradas_sat', 'Entradas pelo SAT'),
+        ('entradas_sieg', 'Entradas pelo Sieg'),
+        ('saidas_sped', 'Saídas por Sped'),
+        ('saidas_xml', 'Saídas por XML'),
+        ('saidas_sieg', 'Saídas pelo SIEG'),
+        ('nfce_sped', 'NFCe por Sped'),
+        ('nfce_xml_sieg', 'NFCe por XML - Sieg'),
+        ('nfce_xml_cliente', 'NFCe por XML - Copiado do cliente'),
+        ('nenhum', 'Não importa nada')
+    ])
+    link_prefeitura = StringField('Link Prefeitura')
+    usuario_prefeitura = StringField('Usuário Prefeitura')
+    senha_prefeitura = PasswordField('Senha Prefeitura')
+    forma_movimento = SelectField('Forma de Recebimento do Movimento', choices=[
+        ('digital', 'Digital'),
+        ('fisico', 'Físico'),
+        ('ambos', 'Digital e Físico')
+    ])
+    envio_digital = SelectMultipleField('Envio Digital', choices=[
+        ('email', 'Email'),
+        ('whatsapp', 'Whatsapp'),
+        ('skype', 'Skype'),
+        ('acessorias', 'Acessórias')
+    ])
+    envio_digital_fisico = SelectMultipleField('Envio Digital e Físico', choices=[
+        ('email', 'Email'),
+        ('whatsapp', 'Whatsapp'),
+        ('skype', 'Skype'),
+        ('acessorias', 'Acessórias'),
+        ('malote', 'Malote')
+    ])
+    observacao_movimento = StringField('Observação')
+    contato_nome = StringField('Nome do Contato')
+    contato_meios = SelectMultipleField('Formas de Contato', choices=[
+        ('email', 'E-mail'),
+        ('whatsapp', 'Whatsapp'),
+        ('skype', 'Skype'),
+        ('ligacao', 'Ligação Telefônica'),
+        ('acessorias', 'Acessórias')
+    ])
+    particularidades = TextAreaField('Particularidades')
+    particularidades_imagens = MultipleFileField('Imagens')
+
+
+class DepartamentoContabilForm(DepartamentoForm):
+    metodo_importacao = SelectField('Forma de Importação', choices=[
+        ('importado', 'Importado'),
+        ('digitado', 'Digitado')
+    ])
+    observacao_importacao = StringField('Observação Importação')
+    forma_movimento = SelectField('Forma de Recebimento do Movimento', choices=[
+        ('digital', 'Digital'),
+        ('fisico', 'Físico'),
+        ('ambos', 'Digital e Físico')
+    ])
+    envio_digital = SelectMultipleField('Envio Digital', choices=[
+        ('email', 'Email'),
+        ('whatsapp', 'Whatsapp'),
+        ('skype', 'Skype'),
+        ('acessorias', 'Acessórias')
+    ])
+    envio_digital_fisico = SelectMultipleField('Envio Digital e Físico', choices=[
+        ('email', 'Email'),
+        ('whatsapp', 'Whatsapp'),
+        ('skype', 'Skype'),
+        ('acessorias', 'Acessórias'),
+        ('malote', 'Malote')
+    ])
+    observacao_movimento = StringField('Observação Movimento')
+    controle_relatorios = SelectMultipleField('Controle por Relatórios', choices=[
+        ('forn_cli_cota_unica', 'Fornecedor e clientes cota unica'),
+        ('saldo_final_mes', 'Relatório com saldo final do mês'),
+        ('adiantamentos', 'Relatório de adiantamentos'),
+        ('contas_pagas', 'Relatório de contas pagas'),
+        ('contas_recebidas', 'Relatório de contas recebidas'),
+        ('adiantamentos2', 'Relatório de adiantamentos'),
+        ('conferir_aplicacao', 'Conferir aplicação')
+    ])
+    observacao_controle_relatorios = StringField('Observação Relatórios')
+    particularidades = TextAreaField('Particularidades')
+    particularidades_imagens = MultipleFileField('Imagens')
+
+
+class DepartamentoPessoalForm(DepartamentoForm):
+    data_envio = StringField('Data de Envio')
+    registro_funcionarios = StringField('Registro de Funcionários')
+    ponto_eletronico = StringField('Ponto Eletrônico')
+    pagamento_funcionario = StringField('Pagamento de Funcionário')
+    particularidades = TextAreaField('Particularidades')
+    particularidades_imagens = MultipleFileField('Imagens')

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -2,7 +2,7 @@ import json
 from sqlalchemy.types import TypeDecorator, String
 from app import db
 from enum import Enum
-from datetime import date
+from datetime import date, datetime
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
 
@@ -67,3 +67,39 @@ class Empresa(db.Model):
 
     def __repr__(self):
         return f"<Empresa {self.NomeEmpresa}>"
+
+
+class Departamento(db.Model):
+    __tablename__ = 'departamentos'
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    empresa_id = db.Column(db.Integer, db.ForeignKey('tbl_empresas.id'), nullable=False)
+    tipo = db.Column(db.String(50), nullable=False)
+    responsavel = db.Column(db.String(100))
+    descricao = db.Column(db.String(200))
+    formas_importacao = db.Column(JsonString(255))
+    link_prefeitura = db.Column(db.String(200))
+    usuario_prefeitura = db.Column(db.String(100))
+    senha_prefeitura = db.Column(db.String(100))
+    forma_movimento = db.Column(db.String(20))
+    envio_digital = db.Column(JsonString(200))
+    envio_digital_fisico = db.Column(JsonString(200))
+    observacao_movimento = db.Column(db.String(200))
+    metodo_importacao = db.Column(db.String(20))
+    observacao_importacao = db.Column(db.String(200))
+    controle_relatorios = db.Column(JsonString(255))
+    observacao_controle_relatorios = db.Column(db.String(200))
+    contatos = db.Column(JsonString(255))
+    data_envio = db.Column(db.String(100))
+    registro_funcionarios = db.Column(db.String(200))
+    ponto_eletronico = db.Column(db.String(200))
+    pagamento_funcionario = db.Column(db.String(200))
+    particularidades_texto = db.Column(db.Text)
+    particularidades_imagens = db.Column(JsonString(255))
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    empresa = db.relationship('Empresa', backref=db.backref('departamentos', lazy=True))
+
+    def __repr__(self):
+        return f"<Departamento {self.tipo} - Empresa {self.empresa_id}>"
+

--- a/app/templates/departamentos/cadastrar.html
+++ b/app/templates/departamentos/cadastrar.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}Cadastrar Departamento{% endblock %}
+
+{% block content %}
+<div class="container mt-4" style="max-width: 600px;">
+    <div class="card shadow-lg p-4">
+        <h2 class="mb-4 text-center text-primary fw-semibold">{{ tipo_nome }} - {{ empresa.NomeEmpresa }}</h2>
+        <form method="POST">
+            {{ form.hidden_tag() }}
+            <div class="form-floating mb-3">
+                {{ form.responsavel(class="form-control", placeholder="Responsável") }}
+                {{ form.responsavel.label(class="form-label") }}
+            </div>
+            <div class="form-floating mb-3">
+                {{ form.descricao(class="form-control", placeholder="Descrição") }}
+                {{ form.descricao.label(class="form-label") }}
+            </div>
+            <div class="d-flex justify-content-center mt-4">
+                <button type="submit" class="btn btn-primary px-5 rounded-pill">Salvar</button>
+            </div>
+        </form>
+        {% if departamento and departamento.updated_at %}
+        <p class="text-muted mt-3 text-end">Última atualização: {{ departamento.updated_at.strftime('%d/%m/%Y %H:%M') }}</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+
+{% block title %}Cadastrar Departamento Contábil{% endblock %}
+
+{% block content %}
+<div class="container mt-4" style="max-width: 800px;">
+    <div class="card shadow-lg p-4">
+        <h2 class="mb-4 text-center text-primary fw-semibold">{{ tipo_nome }} - {{ empresa.NomeEmpresa }}</h2>
+        <form method="POST" enctype="multipart/form-data">
+            {{ form.hidden_tag() }}
+            <div class="row g-4">
+                <div class="col-md-6">
+                    <div class="form-floating mb-3">
+                        {{ form.responsavel(class="form-control", placeholder="Responsável") }}
+                        {{ form.responsavel.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.descricao(class="form-control", placeholder="Descrição") }}
+                        {{ form.descricao.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ form.metodo_importacao.label.text }}</label>
+                        {{ form.metodo_importacao(class="form-select") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.observacao_importacao(class="form-control", placeholder="Observação") }}
+                        {{ form.observacao_importacao.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ form.forma_movimento.label.text }}</label>
+                        {{ form.forma_movimento(class="form-select") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ form.envio_digital.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                        {% for value, label in form.envio_digital.choices %}
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="checkbox" name="{{ form.envio_digital.name }}[]" value="{{ value }}" id="ed-{{ loop.index }}" {% if value in form.envio_digital.data %}checked{% endif %}>
+                                <label class="form-check-label" for="ed-{{ loop.index }}">{{ label }}</label>
+                            </div>
+                        {% endfor %}
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ form.envio_digital_fisico.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                        {% for value, label in form.envio_digital_fisico.choices %}
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="checkbox" name="{{ form.envio_digital_fisico.name }}[]" value="{{ value }}" id="edf-{{ loop.index }}" {% if value in form.envio_digital_fisico.data %}checked{% endif %}>
+                                <label class="form-check-label" for="edf-{{ loop.index }}">{{ label }}</label>
+                            </div>
+                        {% endfor %}
+                        </div>
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.observacao_movimento(class="form-control", placeholder="Observação") }}
+                        {{ form.observacao_movimento.label(class="form-label") }}
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="mb-3">
+                        <label class="form-label">{{ form.controle_relatorios.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                        {% for value, label in form.controle_relatorios.choices %}
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="checkbox" name="{{ form.controle_relatorios.name }}[]" value="{{ value }}" id="cr-{{ loop.index }}" {% if value in form.controle_relatorios.data %}checked{% endif %}>
+                                <label class="form-check-label" for="cr-{{ loop.index }}">{{ label }}</label>
+                            </div>
+                        {% endfor %}
+                        </div>
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.observacao_controle_relatorios(class="form-control", placeholder="Observação") }}
+                        {{ form.observacao_controle_relatorios.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.particularidades(class="form-control", rows=3, placeholder="Particularidades") }}
+                        {{ form.particularidades.label(class="form-label mt-2") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.particularidades_imagens(class="form-control", multiple=True) }}
+                        {{ form.particularidades_imagens.label(class="form-label mt-2") }}
+                    </div>
+                </div>
+            </div>
+            <div class="d-flex justify-content-center mt-4">
+                <button type="submit" class="btn btn-primary px-5 rounded-pill">Salvar</button>
+            </div>
+        </form>
+        {% if departamento and departamento.updated_at %}
+        <p class="text-muted mt-3 text-end">Última atualização: {{ departamento.updated_at.strftime('%d/%m/%Y %H:%M') }}</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+
+{% block title %}Cadastrar Departamento Fiscal{% endblock %}
+
+{% block content %}
+<div class="container mt-4" style="max-width: 800px;">
+    <div class="card shadow-lg p-4">
+        <h2 class="mb-4 text-center text-primary fw-semibold">{{ tipo_nome }} - {{ empresa.NomeEmpresa }}</h2>
+        <form method="POST" enctype="multipart/form-data">
+            {{ form.hidden_tag() }}
+            <div class="row g-4">
+                <div class="col-md-6">
+                    <div class="form-floating mb-3">
+                        {{ form.responsavel(class="form-control", placeholder="Responsável") }}
+                        {{ form.responsavel.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.descricao(class="form-control", placeholder="Descrição") }}
+                        {{ form.descricao.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ form.formas_importacao.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                        {% for value, label in form.formas_importacao.choices %}
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="checkbox" name="{{ form.formas_importacao.name }}[]" value="{{ value }}" id="imp-{{ loop.index }}" {% if value in form.formas_importacao.data %}checked{% endif %}>
+                                <label class="form-check-label" for="imp-{{ loop.index }}">{{ label }}</label>
+                            </div>
+                        {% endfor %}
+                        </div>
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.link_prefeitura(class="form-control", placeholder="Link Prefeitura") }}
+                        {{ form.link_prefeitura.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.usuario_prefeitura(class="form-control", placeholder="Usuário") }}
+                        {{ form.usuario_prefeitura.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.senha_prefeitura(class="form-control", placeholder="Senha") }}
+                        {{ form.senha_prefeitura.label(class="form-label") }}
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="mb-3">
+                        <label class="form-label">{{ form.forma_movimento.label.text }}</label>
+                        {{ form.forma_movimento(class="form-select") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ form.envio_digital.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                        {% for value, label in form.envio_digital.choices %}
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="checkbox" name="{{ form.envio_digital.name }}[]" value="{{ value }}" id="ed-{{ loop.index }}" {% if value in form.envio_digital.data %}checked{% endif %}>
+                                <label class="form-check-label" for="ed-{{ loop.index }}">{{ label }}</label>
+                            </div>
+                        {% endfor %}
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ form.envio_digital_fisico.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                        {% for value, label in form.envio_digital_fisico.choices %}
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="checkbox" name="{{ form.envio_digital_fisico.name }}[]" value="{{ value }}" id="edf-{{ loop.index }}" {% if value in form.envio_digital_fisico.data %}checked{% endif %}>
+                                <label class="form-check-label" for="edf-{{ loop.index }}">{{ label }}</label>
+                            </div>
+                        {% endfor %}
+                        </div>
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.observacao_movimento(class="form-control", placeholder="Observação") }}
+                        {{ form.observacao_movimento.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.contato_nome(class="form-control", placeholder="Nome do Contato") }}
+                        {{ form.contato_nome.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ form.contato_meios.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                        {% for value, label in form.contato_meios.choices %}
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="checkbox" name="{{ form.contato_meios.name }}[]" value="{{ value }}" id="cm-{{ loop.index }}" {% if value in form.contato_meios.data %}checked{% endif %}>
+                                <label class="form-check-label" for="cm-{{ loop.index }}">{{ label }}</label>
+                            </div>
+                        {% endfor %}
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        {{ form.particularidades(class="form-control", rows=3, placeholder="Particularidades") }}
+                        {{ form.particularidades.label(class="form-label mt-2") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.particularidades_imagens(class="form-control", multiple=True) }}
+                        {{ form.particularidades_imagens.label(class="form-label mt-2") }}
+                    </div>
+                </div>
+            </div>
+            <div class="d-flex justify-content-center mt-4">
+                <button type="submit" class="btn btn-primary px-5 rounded-pill">Salvar</button>
+            </div>
+        </form>
+        {% if departamento and departamento.updated_at %}
+        <p class="text-muted mt-3 text-end">Última atualização: {{ departamento.updated_at.strftime('%d/%m/%Y %H:%M') }}</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/departamentos/cadastrar_pessoal.html
+++ b/app/templates/departamentos/cadastrar_pessoal.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+
+{% block title %}Cadastrar Departamento Pessoal{% endblock %}
+
+{% block content %}
+<div class="container mt-4" style="max-width: 800px;">
+    <div class="card shadow-lg p-4">
+        <h2 class="mb-4 text-center text-primary fw-semibold">{{ tipo_nome }} - {{ empresa.NomeEmpresa }}</h2>
+        <form method="POST" enctype="multipart/form-data">
+            {{ form.hidden_tag() }}
+            <div class="row g-4">
+                <div class="col-md-6">
+                    <div class="form-floating mb-3">
+                        {{ form.responsavel(class="form-control", placeholder="Responsável") }}
+                        {{ form.responsavel.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.descricao(class="form-control", placeholder="Descrição") }}
+                        {{ form.descricao.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.data_envio(class="form-control", placeholder="Data de Envio") }}
+                        {{ form.data_envio.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.registro_funcionarios(class="form-control", placeholder="Registro de Funcionários") }}
+                        {{ form.registro_funcionarios.label(class="form-label") }}
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="form-floating mb-3">
+                        {{ form.ponto_eletronico(class="form-control", placeholder="Ponto Eletrônico") }}
+                        {{ form.ponto_eletronico.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ form.pagamento_funcionario(class="form-control", placeholder="Pagamento de Funcionário") }}
+                        {{ form.pagamento_funcionario.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.particularidades(class="form-control", rows=3, placeholder="Particularidades") }}
+                        {{ form.particularidades.label(class="form-label mt-2") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.particularidades_imagens(class="form-control", multiple=True) }}
+                        {{ form.particularidades_imagens.label(class="form-label mt-2") }}
+                    </div>
+                </div>
+            </div>
+            <div class="d-flex justify-content-center mt-4">
+                <button type="submit" class="btn btn-primary px-5 rounded-pill">Salvar</button>
+            </div>
+        </form>
+        {% if departamento and departamento.updated_at %}
+        <p class="text-muted mt-3 text-end">Última atualização: {{ departamento.updated_at.strftime('%d/%m/%Y %H:%M') }}</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- introduce DepartamentoPessoalForm for employee management data
- persist pessoal fields in Departamento model
- implement dedicated route to save departamento pessoal
- create cadastro template for departamento pessoal

## Testing
- `python -m py_compile app/models/tables.py app/forms.py app/controllers/routes.py`


------
https://chatgpt.com/codex/tasks/task_b_685ec6f421fc832aa6d076a966d882a7

## Summary by Sourcery

Add end-to-end support for department management by defining a new Departamento model, corresponding forms, registration routes, and templates for fiscal, accounting, HR, and administrative departments

New Features:
- Introduce Departamento model to store various department types for each company
- Add base DepartamentoForm and specialized forms for fiscal, accounting, and HR departments
- Implement new routes to register fiscal, accounting, HR, and administrative departments
- Create registration templates for each department type

Enhancements:
- Consolidate administrative department registration using a shared helper function