### PR TITLE
Update auth and department management

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -42,6 +42,8 @@ def login():
     return render_template('login.html', form=form)
 
 @app.route('/register', methods=['GET', 'POST'])
+@login_required
+@admin_required
 def register():
     form = RegistrationForm()
     if form.validate_on_submit():
@@ -254,10 +256,6 @@ def gerenciar_departamentos(empresa_id):
         administrativo=administrativo,
     )
 
-@app.route('/empresa/<int:empresa_id>/departamentos/administrativo', methods=['GET', 'POST'])
-@login_required
-def cadastrar_departamento_administrativo(empresa_id):
-    return _cadastrar_departamento(empresa_id, 'Departamento Administrativo')
 
 @app.route('/relatorios')
 @login_required

--- a/app/templates/empresas/listar.html
+++ b/app/templates/empresas/listar.html
@@ -25,6 +25,9 @@
                     <td class="cnpj-col">{{ empresa.CNPJ }}</td>
                     <td>{{ empresa.DataAbertura.strftime('%d/%m/%Y') if empresa.DataAbertura else 'N/A' }}</td>
                     <td class="acao-col text-center">
+                        <a href="{{ url_for('gerenciar_departamentos', empresa_id=empresa.id) }}" class="btn btn-sm btn-secondary" title="Departamentos">
+                            <i class="bi bi-folder"></i>
+                        </a>
                         <a href="{{ url_for('editar_empresa', id=empresa.id) }}" class="btn btn-sm btn-primary" title="Editar empresa">
                             <i class="bi bi-pencil"></i>
                         </a>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -86,9 +86,6 @@
                 <div class="action-btn">
                     <a href="{{ url_for('login') }}" class="btn btn-primary shadow">Entrar</a>
                 </div>
-                <div class="action-btn">
-                    <a href="{{ url_for('register') }}" class="btn btn-outline-primary shadow">Registrar</a>
-                </div>
             </div>
         </section>
     </main>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -60,9 +60,6 @@
             </button>
         </form>
 
-        <p class="mt-3 text-center">
-            Novo por aqui? <a href="{{ url_for('register') }}">Crie uma conta</a>
-        </p>
     </div>
 
     <!-- Bootstrap JS -->


### PR DESCRIPTION
## Summary
- restrict the `/register` route to authenticated admins
- remove registration links from Home and Login pages
- add button to manage departments on the company list
- drop unused department route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685edf4c5e2c832a873019c8d378bd3c

## Summary by Sourcery

Restrict user registration to administrators, clean up registration UI by removing public register links, introduce a department management button on company listings, and remove dead department route code.

Enhancements:
- Restrict access to the registration endpoint to authenticated administrators
- Remove registration links from the Home and Login pages
- Add a "Manage Departments" button on the company listing page

Chores:
- Remove the unused administrative department registration route