### PR TITLE
Update auth and department management

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -42,6 +42,8 @@ def login():
     return render_template('login.html', form=form)
 
 @app.route('/register', methods=['GET', 'POST'])
+@login_required
+@admin_required
 def register():
     form = RegistrationForm()
     if form.validate_on_submit():
@@ -201,7 +203,6 @@ def gerenciar_departamentos(empresa_id):
         contabil.responsavel = contabil_form.responsavel.data
         contabil.descricao = contabil_form.descricao.data
         contabil.metodo_importacao = contabil_form.metodo_importacao.data
-        contabil.observacao_importacao = contabil_form.observacao_importacao.data
         contabil.forma_movimento = contabil_form.forma_movimento.data
         contabil.envio_digital = contabil_form.envio_digital.data
         contabil.envio_digital_fisico = contabil_form.envio_digital_fisico.data
@@ -254,10 +255,6 @@ def gerenciar_departamentos(empresa_id):
         administrativo=administrativo,
     )
 
-@app.route('/empresa/<int:empresa_id>/departamentos/administrativo', methods=['GET', 'POST'])
-@login_required
-def cadastrar_departamento_administrativo(empresa_id):
-    return _cadastrar_departamento(empresa_id, 'Departamento Administrativo')
 
 @app.route('/relatorios')
 @login_required

--- a/app/forms.py
+++ b/app/forms.py
@@ -114,7 +114,6 @@ class DepartamentoContabilForm(DepartamentoForm):
         ('importado', 'Importado'),
         ('digitado', 'Digitado')
     ])
-    observacao_importacao = StringField('Observação Importação')
     forma_movimento = SelectField('Forma de Recebimento do Movimento', choices=[
         ('digital', 'Digital'),
         ('fisico', 'Físico'),
@@ -153,4 +152,5 @@ class DepartamentoPessoalForm(DepartamentoForm):
     ponto_eletronico = StringField('Ponto Eletrônico')
     pagamento_funcionario = StringField('Pagamento de Funcionário')
     particularidades = TextAreaField('Particularidades')
+    particularidades_imagens = MultipleFileField('Imagens')
 

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -86,7 +86,6 @@ class Departamento(db.Model):
     envio_digital_fisico = db.Column(JsonString(200))
     observacao_movimento = db.Column(db.String(200))
     metodo_importacao = db.Column(db.String(20))
-    observacao_importacao = db.Column(db.String(200))
     controle_relatorios = db.Column(JsonString(255))
     observacao_controle_relatorios = db.Column(db.String(200))
     contatos = db.Column(JsonString(255))

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -22,10 +22,6 @@
                         <label class="form-label">{{ form.metodo_importacao.label.text }}</label>
                         {{ form.metodo_importacao(class="form-select") }}
                     </div>
-                    <div class="form-floating mb-3">
-                        {{ form.observacao_importacao(class="form-control", placeholder="Observação") }}
-                        {{ form.observacao_importacao.label(class="form-label") }}
-                    </div>
                     <div class="mb-3">
                         <label class="form-label">{{ form.forma_movimento.label.text }}</label>
                         {{ form.forma_movimento(class="form-select") }}

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -140,10 +140,6 @@
                             <label class="form-label">{{ contabil_form.metodo_importacao.label.text }}</label>
                             {{ contabil_form.metodo_importacao(class="form-select") }}
                         </div>
-                        <div class="form-floating mb-3">
-                            {{ contabil_form.observacao_importacao(class="form-control", placeholder="Observação") }}
-                            {{ contabil_form.observacao_importacao.label(class="form-label") }}
-                        </div>
                         <div class="mb-3">
                             <label class="form-label">{{ contabil_form.forma_movimento.label.text }}</label>
                             {{ contabil_form.forma_movimento(class="form-select") }}

--- a/app/templates/empresas/listar.html
+++ b/app/templates/empresas/listar.html
@@ -25,6 +25,9 @@
                     <td class="cnpj-col">{{ empresa.CNPJ }}</td>
                     <td>{{ empresa.DataAbertura.strftime('%d/%m/%Y') if empresa.DataAbertura else 'N/A' }}</td>
                     <td class="acao-col text-center">
+                        <a href="{{ url_for('gerenciar_departamentos', empresa_id=empresa.id) }}" class="btn btn-sm btn-secondary" title="Departamentos">
+                            <i class="bi bi-folder"></i>
+                        </a>
                         <a href="{{ url_for('editar_empresa', id=empresa.id) }}" class="btn btn-sm btn-primary" title="Editar empresa">
                             <i class="bi bi-pencil"></i>
                         </a>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -86,9 +86,6 @@
                 <div class="action-btn">
                     <a href="{{ url_for('login') }}" class="btn btn-primary shadow">Entrar</a>
                 </div>
-                <div class="action-btn">
-                    <a href="{{ url_for('register') }}" class="btn btn-outline-primary shadow">Registrar</a>
-                </div>
             </div>
         </section>
     </main>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -60,9 +60,6 @@
             </button>
         </form>
 
-        <p class="mt-3 text-center">
-            Novo por aqui? <a href="{{ url_for('register') }}">Crie uma conta</a>
-        </p>
     </div>
 
     <!-- Bootstrap JS -->


### PR DESCRIPTION
## Summary
- restrict the `/register` route to authenticated admins
- remove registration links from Home and Login pages
- add button to manage departments on the company list
- drop unused department route
- fix missing `particularidades_imagens` field in `DepartamentoPessoalForm`
- drop `observacao_importacao` field to match the MySQL schema

## Testing
- `python -m py_compile app/forms.py app/controllers/routes.py`


------
https://chatgpt.com/codex/tasks/task_b_685edf4c5e2c832a873019c8d378bd3c