### PR TITLE
Update department layout

### DIFF
--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -5,27 +5,13 @@
 {% block content %}
 <div class="container mt-4" style="max-width: 1000px;">
     <h2 class="mb-4 text-center text-primary fw-semibold">Departamentos - {{ empresa.NomeEmpresa }}</h2>
-    <ul class="nav nav-tabs" id="depTabs" role="tablist">
-        <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="fiscal-tab" data-bs-toggle="tab" data-bs-target="#fiscal" type="button" role="tab">Fiscal</button>
-        </li>
-        <li class="nav-item" role="presentation">
-            <button class="nav-link" id="contabil-tab" data-bs-toggle="tab" data-bs-target="#contabil" type="button" role="tab">Contábil</button>
-        </li>
-        <li class="nav-item" role="presentation">
-            <button class="nav-link" id="pessoal-tab" data-bs-toggle="tab" data-bs-target="#pessoal" type="button" role="tab">Pessoal</button>
-        </li>
-        <li class="nav-item" role="presentation">
-            <button class="nav-link" id="adm-tab" data-bs-toggle="tab" data-bs-target="#adm" type="button" role="tab">Administrativo</button>
-        </li>
-    </ul>
-    <div class="tab-content border border-top-0 p-4" id="depTabsContent">
-        <div class="tab-pane fade show active" id="fiscal" role="tabpanel">
-            <form method="POST" enctype="multipart/form-data">
-                {{ fiscal_form.hidden_tag() }}
-                <input type="hidden" name="form_type" value="fiscal">
-                <div class="row g-3">
-                    <div class="col-md-6">
+    <div class="border p-4 mb-5" id="fiscal">
+        <h3 class="h5 mb-4">Departamento Fiscal</h3>
+        <form method="POST" enctype="multipart/form-data">
+            {{ fiscal_form.hidden_tag() }}
+            <input type="hidden" name="form_type" value="fiscal">
+            <div class="row g-3">
+                <div class="col-md-6">
                         <div class="form-floating mb-3">
                             {{ fiscal_form.responsavel(class="form-control", placeholder="Responsável") }}
                             {{ fiscal_form.responsavel.label(class="form-label") }}
@@ -122,7 +108,8 @@
             <p class="text-muted mt-2 text-end">Última atualização: {{ fiscal.updated_at.strftime('%d/%m/%Y %H:%M') }}</p>
             {% endif %}
         </div>
-        <div class="tab-pane fade" id="contabil" role="tabpanel">
+        <div class="border p-4 mb-5" id="contabil">
+            <h3 class="h5 mb-4">Departamento Contábil</h3>
             <form method="POST" enctype="multipart/form-data">
                 {{ contabil_form.hidden_tag() }}
                 <input type="hidden" name="form_type" value="contabil">
@@ -205,7 +192,8 @@
             <p class="text-muted mt-2 text-end">Última atualização: {{ contabil.updated_at.strftime('%d/%m/%Y %H:%M') }}</p>
             {% endif %}
         </div>
-        <div class="tab-pane fade" id="pessoal" role="tabpanel">
+        <div class="border p-4 mb-5" id="pessoal">
+            <h3 class="h5 mb-4">Departamento Pessoal</h3>
             <form method="POST" enctype="multipart/form-data">
                 {{ pessoal_form.hidden_tag() }}
                 <input type="hidden" name="form_type" value="pessoal">
@@ -255,7 +243,8 @@
             <p class="text-muted mt-2 text-end">Última atualização: {{ pessoal.updated_at.strftime('%d/%m/%Y %H:%M') }}</p>
             {% endif %}
         </div>
-        <div class="tab-pane fade" id="adm" role="tabpanel">
+        <div class="border p-4 mb-5" id="adm">
+            <h3 class="h5 mb-4">Departamento Administrativo</h3>
             <form method="POST">
                 {{ administrativo_form.hidden_tag() }}
                 <input type="hidden" name="form_type" value="administrativo">
@@ -275,6 +264,5 @@
             <p class="text-muted mt-2 text-end">Última atualização: {{ administrativo.updated_at.strftime('%d/%m/%Y %H:%M') }}</p>
             {% endif %}
         </div>
-    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show departments sequentially instead of tabs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685eeb494c18832a88fe26dfb4a8f52f

## Summary by Sourcery

Enhancements:
- Replace department tabs with sequential bordered sections for each department form