### PR TITLE
Add full company edit page with departments

### DIFF
--- a/app/templates/empresas/editar_empresa.html
+++ b/app/templates/empresas/editar_empresa.html
@@ -3,27 +3,382 @@
 {% block title %}Editar Empresa{% endblock %}
 
 {% block content %}
-<div class="container mt-4" style="max-width: 800px;">
-    <h2 class="mb-4 text-center">Editar Empresa</h2>
-    <form method="POST">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <div class="mb-3">
-            <label for="nome" class="form-label">Nome</label>
-            <input type="text" class="form-control" id="nome" name="nome" value="{{ empresa.NomeEmpresa }}" required>
-        </div>
-        <div class="mb-3">
-            <label for="cnpj" class="form-label">CNPJ</label>
-            <input type="text" class="form-control" id="cnpj" name="cnpj" value="{{ empresa.CNPJ }}" required>
-        </div>
-        <div class="mb-3">
-            <label for="data_abertura" class="form-label">Data de Abertura</label>
-            <input type="date" class="form-control" id="data_abertura" name="data_abertura"
-                value="{{ empresa.DataAbertura if empresa.DataAbertura }}">
-        </div>
-        <div class="text-center">
-            <button type="submit" class="btn btn-primary px-4">Salvar Alterações</button>
-            <a href="{{ url_for('listar_empresas') }}" class="btn btn-secondary px-4">Cancelar</a>
-        </div>
-    </form>
+<div class="container mt-4" style="max-width: 1000px;">
+    <h2 class="mb-4 text-center text-primary fw-semibold">Editar Empresa - {{ empresa.NomeEmpresa }}</h2>
+
+    <div class="border p-4 mb-5" id="dados-empresa">
+        <h3 class="h5 mb-4">Dados da Empresa</h3>
+        <form method="POST">
+            {{ empresa_form.hidden_tag() }}
+            <input type="hidden" name="form_type" value="empresa">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <div class="form-floating mb-3">
+                        {{ empresa_form.codigo_empresa(class="form-control", placeholder="Código") }}
+                        {{ empresa_form.codigo_empresa.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ empresa_form.nome_empresa(class="form-control", placeholder="Nome") }}
+                        {{ empresa_form.nome_empresa.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ empresa_form.cnpj(class="form-control", placeholder="CNPJ") }}
+                        {{ empresa_form.cnpj.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ empresa_form.data_abertura.label.text }}</label>
+                        {{ empresa_form.data_abertura(class="form-control", type="date") }}
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="form-floating mb-3">
+                        {{ empresa_form.socio_administrador(class="form-control", placeholder="Sócio Administrador") }}
+                        {{ empresa_form.socio_administrador.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ empresa_form.tributacao.label.text }}</label>
+                        <div class="d-flex flex-column gap-2">
+                            {% for value, label in empresa_form.tributacao.choices %}
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="{{ empresa_form.tributacao.name }}" value="{{ value }}" id="trib-{{ loop.index }}" {% if empresa_form.tributacao.data == value %}checked{% endif %}>
+                                <label class="form-check-label" for="trib-{{ loop.index }}">{{ label }}</label>
+                            </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ empresa_form.regime_lancamento.label.text }}</label>
+                        <div class="d-flex flex-column gap-2">
+                            {% for value, label in empresa_form.regime_lancamento.choices %}
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="{{ empresa_form.regime_lancamento.name }}" value="{{ value }}" id="reg-{{ loop.index }}" {% if empresa_form.regime_lancamento.data == value %}checked{% endif %}>
+                                <label class="form-check-label" for="reg-{{ loop.index }}">{{ label }}</label>
+                            </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ empresa_form.atividade_principal(class="form-control", placeholder="Atividade") }}
+                        {{ empresa_form.atividade_principal.label(class="form-label") }}
+                    </div>
+                </div>
+            </div>
+            <div class="mb-3 mt-3">
+                <label class="form-label">{{ empresa_form.sistemas_consultorias.label.text }}</label>
+                <div class="d-flex flex-wrap gap-3">
+                    {% for value, label in empresa_form.sistemas_consultorias.choices %}
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="checkbox" name="{{ empresa_form.sistemas_consultorias.name }}[]" value="{{ value }}" id="sis-{{ loop.index }}" {% if value in (empresa_form.sistemas_consultorias.data or []) %}checked{% endif %}>
+                        <label class="form-check-label" for="sis-{{ loop.index }}">{{ label }}</label>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+            <div class="form-floating mb-3">
+                {{ empresa_form.sistema_utilizado(class="form-control", placeholder="Sistema") }}
+                {{ empresa_form.sistema_utilizado.label(class="form-label") }}
+            </div>
+            <div class="d-flex justify-content-center mt-3">
+                <button type="submit" class="btn btn-primary px-5">Salvar Dados da Empresa</button>
+            </div>
+        </form>
+    </div>
+
+    <!-- Departamento Fiscal -->
+    <div class="border p-4 mb-5" id="fiscal">
+        <h3 class="h5 mb-4">Departamento Fiscal</h3>
+        <form method="POST" enctype="multipart/form-data">
+            {{ fiscal_form.hidden_tag() }}
+            <input type="hidden" name="form_type" value="fiscal">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <div class="form-floating mb-3">
+                        {{ fiscal_form.responsavel(class="form-control", placeholder="Responsável") }}
+                        {{ fiscal_form.responsavel.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ fiscal_form.descricao(class="form-control", placeholder="Descrição") }}
+                        {{ fiscal_form.descricao.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ fiscal_form.formas_importacao.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                            {% for value, label in fiscal_form.formas_importacao.choices %}
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="checkbox" name="{{ fiscal_form.formas_importacao.name }}[]" value="{{ value }}" id="fi-{{ loop.index }}" {% if value in (fiscal_form.formas_importacao.data or []) %}checked{% endif %}>
+                                    <label class="form-check-label" for="fi-{{ loop.index }}">{{ label }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ fiscal_form.link_prefeitura(class="form-control", placeholder="Link") }}
+                        {{ fiscal_form.link_prefeitura.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ fiscal_form.usuario_prefeitura(class="form-control", placeholder="Usuário") }}
+                        {{ fiscal_form.usuario_prefeitura.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ fiscal_form.senha_prefeitura(class="form-control", placeholder="Senha") }}
+                        {{ fiscal_form.senha_prefeitura.label(class="form-label") }}
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="mb-3">
+                        <label class="form-label">{{ fiscal_form.forma_movimento.label.text }}</label>
+                        {{ fiscal_form.forma_movimento(class="form-select") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ fiscal_form.envio_digital.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                            {% for value, label in fiscal_form.envio_digital.choices %}
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="checkbox" name="{{ fiscal_form.envio_digital.name }}[]" value="{{ value }}" id="fed-{{ loop.index }}" {% if value in (fiscal_form.envio_digital.data or []) %}checked{% endif %}>
+                                    <label class="form-check-label" for="fed-{{ loop.index }}">{{ label }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ fiscal_form.envio_digital_fisico.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                            {% for value, label in fiscal_form.envio_digital_fisico.choices %}
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="checkbox" name="{{ fiscal_form.envio_digital_fisico.name }}[]" value="{{ value }}" id="fedf-{{ loop.index }}" {% if value in (fiscal_form.envio_digital_fisico.data or []) %}checked{% endif %}>
+                                    <label class="form-check-label" for="fedf-{{ loop.index }}">{{ label }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ fiscal_form.observacao_movimento(class="form-control", placeholder="Observação") }}
+                        {{ fiscal_form.observacao_movimento.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ fiscal_form.contato_nome(class="form-control", placeholder="Nome do Contato") }}
+                        {{ fiscal_form.contato_nome.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ fiscal_form.contato_meios.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                            {% for value, label in fiscal_form.contato_meios.choices %}
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="checkbox" name="{{ fiscal_form.contato_meios.name }}[]" value="{{ value }}" id="fcm-{{ loop.index }}" {% if value in (fiscal_form.contato_meios.data or []) %}checked{% endif %}>
+                                    <label class="form-check-label" for="fcm-{{ loop.index }}">{{ label }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        {{ fiscal_form.particularidades(class="form-control", rows=3, placeholder="Particularidades") }}
+                        {{ fiscal_form.particularidades.label(class="form-label mt-2") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ fiscal_form.particularidades_imagens(class="form-control", multiple=True) }}
+                        {{ fiscal_form.particularidades_imagens.label(class="form-label mt-2") }}
+                    </div>
+                    {% if fiscal and fiscal.particularidades_imagens %}
+                    <div class="mb-3">
+                        <p class="text-muted small mb-1">Imagens cadastradas:</p>
+                        <ul>
+                            {% for img in fiscal.particularidades_imagens %}
+                            <li>{{ img }}</li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="d-flex justify-content-center mt-3">
+                <button type="submit" class="btn btn-primary px-5">Salvar</button>
+            </div>
+        </form>
+        {% if fiscal and fiscal.updated_at %}
+        <p class="text-muted mt-2 text-end">Última atualização: {{ fiscal.updated_at.strftime('%d/%m/%Y %H:%M') }}</p>
+        {% endif %}
+    </div>
+
+    <!-- Departamento Contábil -->
+    <div class="border p-4 mb-5" id="contabil">
+        <h3 class="h5 mb-4">Departamento Contábil</h3>
+        <form method="POST" enctype="multipart/form-data">
+            {{ contabil_form.hidden_tag() }}
+            <input type="hidden" name="form_type" value="contabil">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <div class="form-floating mb-3">
+                        {{ contabil_form.responsavel(class="form-control", placeholder="Responsável") }}
+                        {{ contabil_form.responsavel.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ contabil_form.descricao(class="form-control", placeholder="Descrição") }}
+                        {{ contabil_form.descricao.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ contabil_form.metodo_importacao.label.text }}</label>
+                        {{ contabil_form.metodo_importacao(class="form-select") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ contabil_form.forma_movimento.label.text }}</label>
+                        {{ contabil_form.forma_movimento(class="form-select") }}
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ contabil_form.envio_digital.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                            {% for value, label in contabil_form.envio_digital.choices %}
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="checkbox" name="{{ contabil_form.envio_digital.name }}[]" value="{{ value }}" id="ced-{{ loop.index }}" {% if value in (contabil_form.envio_digital.data or []) %}checked{% endif %}>
+                                    <label class="form-check-label" for="ced-{{ loop.index }}">{{ label }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">{{ contabil_form.envio_digital_fisico.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                            {% for value, label in contabil_form.envio_digital_fisico.choices %}
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="checkbox" name="{{ contabil_form.envio_digital_fisico.name }}[]" value="{{ value }}" id="cedf-{{ loop.index }}" {% if value in (contabil_form.envio_digital_fisico.data or []) %}checked{% endif %}>
+                                    <label class="form-check-label" for="cedf-{{ loop.index }}">{{ label }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ contabil_form.observacao_movimento(class="form-control", placeholder="Observação") }}
+                        {{ contabil_form.observacao_movimento.label(class="form-label") }}
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="mb-3">
+                        <label class="form-label">{{ contabil_form.controle_relatorios.label.text }}</label>
+                        <div class="d-flex flex-wrap gap-3">
+                            {% for value, label in contabil_form.controle_relatorios.choices %}
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="checkbox" name="{{ contabil_form.controle_relatorios.name }}[]" value="{{ value }}" id="cr-{{ loop.index }}" {% if value in (contabil_form.controle_relatorios.data or []) %}checked{% endif %}>
+                                    <label class="form-check-label" for="cr-{{ loop.index }}">{{ label }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ contabil_form.observacao_controle_relatorios(class="form-control", placeholder="Observação") }}
+                        {{ contabil_form.observacao_controle_relatorios.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ contabil_form.particularidades(class="form-control", rows=3, placeholder="Particularidades") }}
+                        {{ contabil_form.particularidades.label(class="form-label mt-2") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ contabil_form.particularidades_imagens(class="form-control", multiple=True) }}
+                        {{ contabil_form.particularidades_imagens.label(class="form-label mt-2") }}
+                    </div>
+                    {% if contabil and contabil.particularidades_imagens %}
+                    <div class="mb-3">
+                        <p class="text-muted small mb-1">Imagens cadastradas:</p>
+                        <ul>
+                            {% for img in contabil.particularidades_imagens %}
+                            <li>{{ img }}</li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="d-flex justify-content-center mt-3">
+                <button type="submit" class="btn btn-primary px-5">Salvar</button>
+            </div>
+        </form>
+        {% if contabil and contabil.updated_at %}
+        <p class="text-muted mt-2 text-end">Última atualização: {{ contabil.updated_at.strftime('%d/%m/%Y %H:%M') }}</p>
+        {% endif %}
+    </div>
+
+    <!-- Departamento Pessoal -->
+    <div class="border p-4 mb-5" id="pessoal">
+        <h3 class="h5 mb-4">Departamento Pessoal</h3>
+        <form method="POST" enctype="multipart/form-data">
+            {{ pessoal_form.hidden_tag() }}
+            <input type="hidden" name="form_type" value="pessoal">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <div class="form-floating mb-3">
+                        {{ pessoal_form.responsavel(class="form-control", placeholder="Responsável") }}
+                        {{ pessoal_form.responsavel.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ pessoal_form.descricao(class="form-control", placeholder="Descrição") }}
+                        {{ pessoal_form.descricao.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ pessoal_form.data_envio(class="form-control", placeholder="Data de Envio") }}
+                        {{ pessoal_form.data_envio.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ pessoal_form.registro_funcionarios(class="form-control", placeholder="Registro de Funcionários") }}
+                        {{ pessoal_form.registro_funcionarios.label(class="form-label") }}
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="form-floating mb-3">
+                        {{ pessoal_form.ponto_eletronico(class="form-control", placeholder="Ponto Eletrônico") }}
+                        {{ pessoal_form.ponto_eletronico.label(class="form-label") }}
+                    </div>
+                    <div class="form-floating mb-3">
+                        {{ pessoal_form.pagamento_funcionario(class="form-control", placeholder="Pagamento de Funcionário") }}
+                        {{ pessoal_form.pagamento_funcionario.label(class="form-label") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ pessoal_form.particularidades(class="form-control", rows=3, placeholder="Particularidades") }}
+                        {{ pessoal_form.particularidades.label(class="form-label mt-2") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ pessoal_form.particularidades_imagens(class="form-control", multiple=True) }}
+                        {{ pessoal_form.particularidades_imagens.label(class="form-label mt-2") }}
+                    </div>
+                    {% if pessoal and pessoal.particularidades_imagens %}
+                    <div class="mb-3">
+                        <p class="text-muted small mb-1">Imagens cadastradas:</p>
+                        <ul>
+                            {% for img in pessoal.particularidades_imagens %}
+                            <li>{{ img }}</li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="d-flex justify-content-center mt-3">
+                <button type="submit" class="btn btn-primary px-5">Salvar</button>
+            </div>
+        </form>
+        {% if pessoal and pessoal.updated_at %}
+        <p class="text-muted mt-2 text-end">Última atualização: {{ pessoal.updated_at.strftime('%d/%m/%Y %H:%M') }}</p>
+        {% endif %}
+    </div>
+
+    <!-- Departamento Administrativo -->
+    <div class="border p-4 mb-5" id="adm">
+        <h3 class="h5 mb-4">Departamento Administrativo</h3>
+        <form method="POST">
+            {{ administrativo_form.hidden_tag() }}
+            <input type="hidden" name="form_type" value="administrativo">
+            <div class="form-floating mb-3">
+                {{ administrativo_form.responsavel(class="form-control", placeholder="Responsável") }}
+                {{ administrativo_form.responsavel.label(class="form-label") }}
+            </div>
+            <div class="form-floating mb-3">
+                {{ administrativo_form.descricao(class="form-control", placeholder="Descrição") }}
+                {{ administrativo_form.descricao.label(class="form-label") }}
+            </div>
+            <div class="d-flex justify-content-center mt-3">
+                <button type="submit" class="btn btn-primary px-5">Salvar</button>
+            </div>
+        </form>
+        {% if administrativo and administrativo.updated_at %}
+        <p class="text-muted mt-2 text-end">Última atualização: {{ administrativo.updated_at.strftime('%d/%m/%Y %H:%M') }}</p>
+        {% endif %}
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow editing all company fields and department data in one place
- show previously uploaded image names when editing departments

## Testing
- `python -m py_compile app/controllers/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862dc09d2dc832aa72d1c8b654ea7f0

## Summary by Sourcery

Unify and extend the company edit interface to allow inline editing of all company fields and department data using WTForms, including image uploads and existing file previews.

New Features:
- Provide a unified edit page with separate WTForms-driven sections for company and its four departments (Fiscal, Contábil, Pessoal, Administrativo)
- Enable multipart file uploads for department-specific images and display previously uploaded image names on edit

Enhancements:
- Refactor the editar_empresa route to initialize and validate distinct forms per section and persist updates without leaving the page
- Normalize CNPJ input by stripping non-digit characters and adjust post-save redirect to remain on the edit view