### PR TITLE
Add support for image paste

### DIFF
--- a/app/static/javascript/paste_images.js
+++ b/app/static/javascript/paste_images.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const fileInputs = document.querySelectorAll('input[type="file"][multiple]');
+    fileInputs.forEach(function (input) {
+        input.addEventListener('paste', function (e) {
+            if (!e.clipboardData || !e.clipboardData.items) {
+                return;
+            }
+            const images = Array.from(e.clipboardData.items).filter(function (item) {
+                return item.type.startsWith('image/');
+            });
+            if (images.length === 0) {
+                return;
+            }
+            const existing = Array.from(input.files);
+            images.forEach(function (item) {
+                const file = item.getAsFile();
+                if (file) {
+                    existing.push(file);
+                }
+            });
+            const dt = new DataTransfer();
+            existing.forEach(function (file) {
+                dt.items.add(file);
+            });
+            input.files = dt.files;
+            e.preventDefault();
+        });
+    });
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -63,6 +63,7 @@
     {% endwith %}
 
     <script src="{{ url_for('static', filename='javascript/mensagens.js') }}"></script>
+    <script src="{{ url_for('static', filename='javascript/paste_images.js') }}"></script>
 
     <!-- Main Content -->
     <main class="flex-grow-1 container py-4">


### PR DESCRIPTION
## Summary
- allow image paste into file inputs
- include new JS file in base template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6862d00c79dc832aa2918c456fa0cd82

## Summary by Sourcery

Add support for pasting images directly into multiple file input fields by including a new JavaScript handler and wiring it into the base template.

New Features:
- Allow users to paste images from the clipboard into multiple file inputs for uploads.

Enhancements:
- Introduce paste_images.js to listen for paste events and append clipboard images to file inputs.
- Include the new paste_images.js script in the base HTML template.