### PR TITLE
Add company search to listing

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -149,7 +149,11 @@ def cadastrar_empresa():
 @app.route('/listar_empresas')
 @login_required
 def listar_empresas():
-    empresas = Empresa.query.all()
+    search = request.args.get('q', '').strip()
+    query = Empresa.query
+    if search:
+        query = query.filter(Empresa.nome_empresa.ilike(f'%{search}%'))
+    empresas = query.all()
 
     for empresa in empresas:
         if empresa.data_abertura and isinstance(empresa.data_abertura, str):
@@ -158,7 +162,7 @@ def listar_empresas():
             except ValueError:
                 empresa.data_abertura = None
 
-    return render_template('empresas/listar.html', empresas=empresas)
+    return render_template('empresas/listar.html', empresas=empresas, search=search)
 
 def processar_dados_fiscal(request):
     """Função auxiliar para processar dados do departamento fiscal"""

--- a/app/templates/empresas/listar.html
+++ b/app/templates/empresas/listar.html
@@ -22,6 +22,18 @@
         </div>
     </div>
 
+    <!-- Campo de Busca -->
+    <div class="row mb-3">
+        <div class="col-12">
+            <form method="get" action="{{ url_for('listar_empresas') }}" class="input-group">
+                <input type="text" name="q" class="form-control" placeholder="Buscar empresa" value="{{ search }}">
+                <button class="btn btn-outline-secondary" type="submit">
+                    <i class="bi bi-search"></i>
+                </button>
+            </form>
+        </div>
+    </div>
+
     <!-- Mensagens Flash -->
     {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}


### PR DESCRIPTION
## Summary
- allow filtering companies by name via `q` query param
- add search bar on company listing page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b94c7cf10833093ce255ab5c981fb

## Summary by Sourcery

Add company search capability to the company listing page, enabling users to filter companies by name via a query parameter.

New Features:
- Add search input field to the company listing template
- Implement filtering of companies by name using the ‘q’ query parameter