### PR TITLE
Apply blue and orange theme

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3,8 +3,8 @@ Fonte personalizada moderna
 ----------------------------- */
 body {
     font-family: 'Inter', sans-serif;
-    background-color: #f4f4f4;
-    color: #333;
+    background-color: #fff;
+    color: #000;
     margin: 0;
     padding: 0;
     text-align: center;
@@ -52,7 +52,7 @@ Seção Introdução
 
 .intro p {
     font-size: 1.2em;
-    color: #555;
+    color: #000;
 }
 
 /* -----------------------------
@@ -85,7 +85,7 @@ Botões e Ações
 
 .btn:focus, .btn-custom:focus, .submit-btn:focus {
     outline: none;
-    box-shadow: 0 0 0 0.2rem rgba(5, 88, 197, 0.4);
+    box-shadow: 0 0 0 0.2rem rgba(11, 40, 139, 0.4);
 }
 
 .btn-sm {
@@ -108,7 +108,7 @@ Tabelas (Empresas e Usuários)
 
 .user-table th, .user-table td,
 .table-empresas th, .table-empresas td {
-    border: 1px solid #ccc;
+    border: 1px solid rgba(0,0,0,0.2);
     padding: 12px;
     text-align: left;
     vertical-align: middle;
@@ -123,7 +123,7 @@ Tabelas (Empresas e Usuários)
 
 .user-table tr:nth-child(even),
 .table-empresas tbody tr:nth-child(even) {
-    background-color: #f9f9f9;
+    background-color: #fff;
 }
 
 .codigo-col {
@@ -183,7 +183,7 @@ Botões personalizados
 Rodapé
 ----------------------------- */
 footer {
-    background-color: #333;
+    background-color: #000;
     color: white;
     padding: 15px;
     margin-top: 30px;
@@ -220,7 +220,7 @@ label {
     display: block;
     font-size: 0.9rem;
     margin-bottom: 0.3rem;
-    color: #444;
+    color: #000;
 }
 
 input[type="text"],
@@ -228,7 +228,7 @@ input[type="email"],
 input[type="password"] {
     width: 100%;
     padding: 0.8rem;
-    border: 1px solid #ccc;
+    border: 1px solid rgba(0,0,0,0.2);
     border-radius: 5px;
     font-size: 1rem;
     transition: border-color 0.3s ease;
@@ -277,7 +277,7 @@ body.login-page {
 /* Título do formulário de login */
 .login-container h2 {
     font-weight: 600;
-    color: #343a40;
+    color: #000;
     margin-bottom: 1.5rem;
     text-align: center;
     font-size: 1.5rem;
@@ -286,27 +286,27 @@ body.login-page {
 /* Labels específicos do login */
 .login-container .form-label {
     font-weight: 500;
-    color: #495057;
+    color: rgba(0,0,0,0.6);
     margin-bottom: 0.5rem;
     display: block;
 }
 
 /* Ícones nos inputs do login */
 .login-container .input-group-text {
-    background-color: #f8f9fa;
-    border-color: #dee2e6;
-    color: #6c757d;
+    background-color: #fff;
+    border-color: rgba(0,0,0,0.1);
+    color: rgba(0,0,0,0.6);
 }
 
 /* Inputs do formulário de login */
 .login-container .form-control {
-    border-color: #dee2e6;
+    border-color: rgba(0,0,0,0.1);
     padding: 0.75rem;
 }
 
 .login-container .form-control:focus {
     border-color: #0b288b;
-    box-shadow: 0 0 0 0.2rem rgba(75, 148, 243, 0.25);
+    box-shadow: 0 0 0 0.2rem rgba(11, 40, 139, 0.25);
 }
 
 /* Botão principal do login */
@@ -327,13 +327,13 @@ body.login-page {
 
 /* Botão toggle da senha */
 .login-container .btn-outline-secondary {
-    border-color: #dee2e6;
+    border-color: rgba(0,0,0,0.1);
 }
 
 .login-container .btn-outline-secondary:hover {
-    background-color: #f8f9fa;
-    border-color: #dee2e6;
-    color: #6c757d;
+    background-color: #fff;
+    border-color: rgba(0,0,0,0.1);
+    color: rgba(0,0,0,0.6);
 }
 
 /* Textos de erro no login */
@@ -344,7 +344,7 @@ body.login-page {
 /* Label do checkbox "Lembrar-me" */
 .login-container .form-check-label {
     font-size: 0.9rem;
-    color: #6c757d;
+    color: rgba(0,0,0,0.6);
 }
 
 /* Responsividade para tela de login */
@@ -405,17 +405,17 @@ FORMULÁRIOS DE DEPARTAMENTOS - ESTILOS ESPECÍFICOS
 .form-floating > .form-control:focus,
 .form-control:focus {
     border-color: #0b288b;
-    box-shadow: 0 0 0 0.2rem rgba(5, 88, 197, 0.25);
+    box-shadow: 0 0 0 0.2rem rgba(11, 40, 139, 0.25);
 }
 
 .form-select:focus {
     border-color: #0b288b;
-    box-shadow: 0 0 0 0.2rem rgba(5, 88, 197, 0.25);
+    box-shadow: 0 0 0 0.2rem rgba(11, 40, 139, 0.25);
 }
 
 /* Container de checkboxes */
 .bg-light {
-    background-color: #f8f9fa !important;
+    background-color: #fff !important;
 }
 
 /* Editor Quill */
@@ -424,26 +424,26 @@ FORMULÁRIOS DE DEPARTAMENTOS - ESTILOS ESPECÍFICOS
 }
 
 .ql-toolbar {
-    border-top: 1px solid #dee2e6;
-    border-left: 1px solid #dee2e6;
-    border-right: 1px solid #dee2e6;
+    border-top: 1px solid rgba(0,0,0,0.1);
+    border-left: 1px solid rgba(0,0,0,0.1);
+    border-right: 1px solid rgba(0,0,0,0.1);
     border-top-left-radius: 0.375rem;
     border-top-right-radius: 0.375rem;
 }
 
 .ql-container {
-    border-bottom: 1px solid #dee2e6;
-    border-left: 1px solid #dee2e6;
-    border-right: 1px solid #dee2e6;
+    border-bottom: 1px solid rgba(0,0,0,0.1);
+    border-left: 1px solid rgba(0,0,0,0.1);
+    border-right: 1px solid rgba(0,0,0,0.1);
     border-bottom-left-radius: 0.375rem;
     border-bottom-right-radius: 0.375rem;
 }
 
 /* Alerts informativos */
 .alert-info {
-    background-color: #e7f3ff;
-    border-color: #bee5eb;
-    color: #0c5460;
+    background-color: rgba(11,40,139,0.1);
+    border-color: rgba(11,40,139,0.3);
+    color: #0b288b;
 }
 
 /* Labels em negrito */
@@ -488,13 +488,13 @@ FORMULÁRIOS DE DEPARTAMENTOS - ESTILOS ESPECÍFICOS
     z-index: 10;
     border: none;
     background: transparent;
-    color: #6c757d;
+    color: rgba(0,0,0,0.6);
     padding: 0.25rem 0.5rem;
 }
 
 .position-absolute.top-50.end-0.translate-middle-y:hover {
-    background-color: #f8f9fa;
-    color: #495057;
+    background-color: #fff;
+    color: rgba(0,0,0,0.6);
 }
 
 /* -----------------------------
@@ -514,11 +514,11 @@ PÁGINA DE RELATÓRIOS - ESTILOS ESPECÍFICOS
 
 /* Backgrounds sutis para badges */
 .bg-primary-subtle {
-    background-color: rgba(5, 88, 197, 0.1) !important;
+    background-color: rgba(11, 40, 139, 0.1) !important;
 }
 
 .bg-warning-subtle {
-    background-color: rgba(255, 193, 7, 0.1) !important;
+    background-color: rgba(232, 116, 41, 0.1) !important;
 }
 
 /* Cores de borda consistentes */
@@ -528,48 +528,48 @@ PÁGINA DE RELATÓRIOS - ESTILOS ESPECÍFICOS
 
 /* Headers coloridos para os cards de relatório */
 .card-header.bg-success {
-    background-color: #198754 !important;
+    background-color: #0b288b !important;
 }
 
 .card-header.bg-info {
-    background-color: #0dcaf0 !important;
+    background-color: #0b288b !important;
 }
 
 .card-header.bg-dark {
-    background-color: #212529 !important;
+    background-color: #000 !important;
 }
 
 /* Botões coloridos para relatórios */
 .btn-success {
-    background-color: #198754;
-    border-color: #198754;
+    background-color: #0b288b;
+    border-color: #0b288b;
 }
 
 .btn-success:hover {
-    background-color: #157347;
-    border-color: #146c43;
+    background-color: #0b288b;
+    border-color: #0b288b;
 }
 
 .btn-info {
-    background-color: #0dcaf0;
-    border-color: #0dcaf0;
+    background-color: #0b288b;
+    border-color: #0b288b;
     color: #000;
 }
 
 .btn-info:hover {
-    background-color: #31d2f2;
-    border-color: #25cff2;
+    background-color: #0b288b;
+    border-color: #0b288b;
     color: #000;
 }
 
 .btn-dark {
-    background-color: #212529;
-    border-color: #212529;
+    background-color: #000;
+    border-color: #000;
 }
 
 .btn-dark:hover {
-    background-color: #424649;
-    border-color: #373b3e;
+    background-color: #000;
+    border-color: #000;
 }
 
 /* Estilos para cards de altura igual */
@@ -601,11 +601,11 @@ PÁGINA DE RELATÓRIOS - ESTILOS ESPECÍFICOS
 
 /* Ícones coloridos nas listas */
 .text-success {
-    color: #198754 !important;
+    color: #0b288b !important;
 }
 
 .text-warning {
-    color: #ffc107 !important;
+    color: #e87429 !important;
 }
 
 /* Cards com gradiente */
@@ -670,7 +670,7 @@ PÁGINA DE DETALHES DA EMPRESA - ESTILOS ESPECÍFICOS
 /* Labels dos campos de informação */
 .info-label {
     font-weight: 600;
-    color: #495057;
+    color: rgba(0,0,0,0.6);
     font-size: 0.9rem;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -681,7 +681,7 @@ PÁGINA DE DETALHES DA EMPRESA - ESTILOS ESPECÍFICOS
 /* Valores dos campos de informação */
 .info-value {
     font-size: 1rem;
-    color: #212529;
+    color: #000;
     line-height: 1.4;
 }
 
@@ -699,20 +699,20 @@ PÁGINA DE DETALHES DA EMPRESA - ESTILOS ESPECÍFICOS
 
 /* Backgrounds sutis adicionais para badges */
 .bg-success-subtle {
-    background-color: rgba(25, 135, 84, 0.1) !important;
+    background-color: rgba(11, 40, 139, 0.1) !important;
 }
 
 .bg-info-subtle {
-    background-color: rgba(13, 202, 240, 0.1) !important;
+    background-color: rgba(11, 40, 139, 0.1) !important;
 }
 
 /* Cores de texto para badges */
 .text-success {
-    color: #198754 !important;
+    color: #0b288b !important;
 }
 
 .text-info {
-    color: #0dcaf0 !important;
+    color: #0b288b !important;
 }
 
 /* Botões outline personalizados */
@@ -727,13 +727,13 @@ PÁGINA DE DETALHES DA EMPRESA - ESTILOS ESPECÍFICOS
 }
 
 .btn-outline-secondary {
-    color: #6c757d;
-    border-color: #6c757d;
+    color: rgba(0,0,0,0.6);
+    border-color: rgba(0,0,0,0.6);
 }
 
 .btn-outline-secondary:hover {
-    background-color: #6c757d;
-    border-color: #6c757d;
+    background-color: rgba(0,0,0,0.6);
+    border-color: rgba(0,0,0,0.6);
 }
 
 /* Responsividade para página de detalhes */
@@ -769,7 +769,7 @@ PÁGINA DE DETALHES DA EMPRESA - ESTILOS ESPECÍFICOS
 Mensagens de erro
 ----------------------------- */
 .error {
-    color: #e74c3c;
+    color: #e87429;
     font-size: 0.85rem;
     margin-top: 0.3rem;
 }
@@ -810,9 +810,9 @@ Mensagem de login flutuante
     right: 20px;
     max-width: 300px;
     width: auto;
-    background-color: #d4edda;
-    color: #155724;
-    border: 1px solid #c3e6cb;
+    background-color: rgba(11,40,139,0.1);
+    color: #0b288b;
+    border: 1px solid rgba(11,40,139,0.3);
     padding: 12px 16px;
     border-radius: 6px;
     z-index: 9999; /* Aumenta o z-index para garantir que fique acima */
@@ -891,7 +891,7 @@ Mensagem de login flutuante
 }
 
 .table-empresas tbody tr:hover {
-    background-color: rgba(5, 88, 197, 0.05);
+    background-color: rgba(11, 40, 139, 0.05);
     transform: translateY(-1px);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
@@ -982,7 +982,7 @@ Mensagem de login flutuante
 }
 
 .table-empresas tbody tr:hover {
-    background-color: rgba(5, 88, 197, 0.05);
+    background-color: rgba(11, 40, 139, 0.05);
     transform: translateY(-1px);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
@@ -1034,7 +1034,7 @@ Mensagem de login flutuante
 }
 
 .table-hover tbody tr:hover {
-    background-color: rgba(5, 88, 197, 0.05);
+    background-color: rgba(11, 40, 139, 0.05);
 }
 
 /* Ajuste do cabeçalho responsivo em mobile */

--- a/app/templates/admin/relatorios.html
+++ b/app/templates/admin/relatorios.html
@@ -125,7 +125,7 @@
         <!-- Relatório de Departamento Pessoal -->
         <div class="col-lg-4 col-md-6">
             <div class="card shadow-sm border-0 h-100 card-hover">
-                <div class="card-header bg-purple text-white border-0" style="background-color: #6f42c1 !important;">
+                <div class="card-header bg-purple text-white border-0" style="background-color: #0b288b !important;">
                     <div class="d-flex align-items-center">
                         <i class="bi bi-people-fill me-2 fs-4"></i>
                         <h5 class="card-title mb-0">Relatório Pessoal</h5>
@@ -147,7 +147,7 @@
                     </ul>
                 </div>
                 <div class="card-footer bg-transparent border-0">
-                    <button class="btn w-100 disabled" disabled style="background-color: #6f42c1; border-color: #6f42c1; color: white;">
+                    <button class="btn w-100 disabled" disabled style="background-color: #0b288b; border-color: #0b288b; color: white;">
                         <i class="bi bi-tools me-2"></i>Em Breve
                     </button>
                 </div>
@@ -189,7 +189,7 @@
         <!-- Dashboards Gerenciais -->
         <div class="col-lg-4 col-md-6">
             <div class="card shadow-sm border-0 h-100 card-hover">
-                <div class="card-header bg-gradient text-white border-0" style="background: linear-gradient(45deg, #ff6b6b, #ffa726) !important;">
+                <div class="card-header bg-gradient text-white border-0" style="background: linear-gradient(45deg, #0b288b, #e87429) !important;">
                     <div class="d-flex align-items-center">
                         <i class="bi bi-graph-up me-2 fs-4"></i>
                         <h5 class="card-title mb-0">Dashboard Gerencial</h5>
@@ -211,7 +211,7 @@
                     </ul>
                 </div>
                 <div class="card-footer bg-transparent border-0">
-                    <button class="btn w-100 disabled" disabled style="background: linear-gradient(45deg, #ff6b6b, #ffa726); border: none; color: white;">
+                    <button class="btn w-100 disabled" disabled style="background: linear-gradient(45deg, #0b288b, #e87429); border: none; color: white;">
                         <i class="bi bi-tools me-2"></i>Em Breve
                     </button>
                 </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,19 +16,26 @@
         --primary-color: #e87429;
         --primary-dark: #0b288b;
         --sidebar-bg: #ffffff;
-        --sidebar-text: #495057;
-        --sidebar-hover: #fde8d9;
-        --sidebar-active: #fbd1a8;
-        --border-color: #f7c79f;
-        --text-muted: #6c757d;
-        --danger-color: #dc3545;
-        --danger-hover: #c82333;
+        --sidebar-text: #000000;
+        --sidebar-hover: rgba(232,116,41,0.1);
+        --sidebar-active: rgba(232,116,41,0.2);
+        --border-color: rgba(0,0,0,0.1);
+        --text-muted: rgba(0,0,0,0.6);
+        --danger-color: #e87429;
+        --danger-hover: rgba(232,116,41,0.8);
+        --bs-primary: #0b288b;
+        --bs-secondary: #e87429;
+        --bs-success: #0b288b;
+        --bs-info: #0b288b;
+        --bs-warning: #e87429;
+        --bs-danger: #e87429;
+        --bs-dark: #000000;
       }
 
       body, html {
         height: 100%;
         margin: 0;
-        background-color: #f8f9fa;
+        background-color: #fff;
       }
 
       .wrapper {
@@ -166,7 +173,7 @@
       .sidebar-footer {
         padding: 1.25rem;
         border-top: 1px solid var(--border-color);
-        background: #f8f9fa;
+        background: #fff;
       }
 
       .user-profile {
@@ -234,7 +241,7 @@
       .content-area {
         flex-grow: 1;
         overflow-y: auto;
-        background-color: #f8f9fa;
+        background-color: #fff;
         position: relative;
       }
 
@@ -359,11 +366,11 @@
       /* Tema escuro (opcional) */
       @media (prefers-color-scheme: dark) {
         :root {
-          --sidebar-bg: #2c2c2c;
-          --sidebar-text: #e9ecef;
-          --sidebar-hover: #3c3c3c;
-          --sidebar-active: #4c4c4c;
-          --border-color: #495057;
+        --sidebar-bg: #000000;
+        --sidebar-text: #ffffff;
+        --sidebar-hover: rgba(255,255,255,0.1);
+        --sidebar-active: rgba(255,255,255,0.2);
+        --border-color: rgba(255,255,255,0.2);
         }
       }
     </style>
@@ -449,7 +456,7 @@
                             <a class="nav-link" href="#" onclick="return false;" style="opacity: 0.6;">
                                 <i class="bi bi-gear"></i>
                                 Configurações
-                                <small style="margin-left: auto; font-size: 0.6rem; background: #ffc107; color: #000; padding: 0.1rem 0.3rem; border-radius: 0.2rem;">BREVE</small>
+                                <small style="margin-left: auto; font-size: 0.6rem; background: #e87429; color: #000; padding: 0.1rem 0.3rem; border-radius: 0.2rem;">BREVE</small>
                             </a>
                         </li>
                     </ul>

--- a/app/templates/departamentos/cadastrar.html
+++ b/app/templates/departamentos/cadastrar.html
@@ -53,7 +53,7 @@
                         <label class="form-label fw-semibold">
                             <i class="bi bi-image me-1"></i>Editor de Particularidades
                         </label>
-                        <div id="editor" style="height: 300px; border: 1px solid #dee2e6; border-radius: 0.375rem;">
+                        <div id="editor" style="height: 300px; border: 1px solid rgba(0,0,0,0.1); border-radius: 0.375rem;">
                             {{ form.particularidades.data|safe }}
                         </div>
                         {{ form.particularidades(id="particularidades", type="hidden") }}

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -186,7 +186,7 @@
                         <label class="form-label fw-semibold">
                             <i class="bi bi-pencil-square me-1"></i>Editor de Particularidades
                         </label>
-                        <div id="editor" style="height: 200px; border: 1px solid #dee2e6; border-radius: 0.375rem;">
+                        <div id="editor" style="height: 200px; border: 1px solid rgba(0,0,0,0.1); border-radius: 0.375rem;">
                             {{ form.particularidades.data|safe }}
                         </div>
                         {{ form.particularidades(id="particularidades", type="hidden") }}
@@ -319,7 +319,7 @@ document.addEventListener("DOMContentLoaded", function () {
             const label = checkbox.closest('.form-check');
             if (checkbox.checked) {
                 label.style.fontWeight = '600';
-                label.style.color = '#0558c5';
+                label.style.color = '#0b288b';
             } else {
                 label.style.fontWeight = 'normal';
                 label.style.color = '';

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -180,7 +180,7 @@
                         <label class="form-label fw-semibold">
                             <i class="bi bi-image me-1"></i>Editor de Particularidades
                         </label>
-                        <div id="editor" style="height: 250px; border: 1px solid #dee2e6; border-radius: 0.375rem;">
+                        <div id="editor" style="height: 250px; border: 1px solid rgba(0,0,0,0.1); border-radius: 0.375rem;">
                             {{ form.particularidades.data|safe }}
                         </div>
                         {{ form.particularidades_texto(id="particularidades", type="hidden") }}
@@ -313,7 +313,7 @@ document.addEventListener("DOMContentLoaded", function () {
             const label = checkbox.closest('.form-check');
             if (checkbox.checked) {
                 label.style.fontWeight = '600';
-                label.style.color = '#0558c5';
+                label.style.color = '#0b288b';
             } else {
                 label.style.fontWeight = 'normal';
                 label.style.color = '';

--- a/app/templates/departamentos/cadastrar_pessoal.html
+++ b/app/templates/departamentos/cadastrar_pessoal.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="container mt-4" style="max-width: 1000px;">
     <div class="card shadow-lg">
-        <div class="card-header text-white py-3" style="background-color: #f39c12;">
+        <div class="card-header text-white py-3" style="background-color: #e87429;">
             <h2 class="mb-0 text-center fw-semibold">
                 <i class="bi bi-people me-2"></i>{{ tipo_nome }} - {{ empresa.NomeEmpresa }}
             </h2>
@@ -102,7 +102,7 @@
                         <label class="form-label fw-semibold">
                             <i class="bi bi-image me-1"></i>Editor de Particularidades
                         </label>
-                        <div id="editor" style="height: 250px; border: 1px solid #dee2e6; border-radius: 0.375rem;">
+                        <div id="editor" style="height: 250px; border: 1px solid rgba(0,0,0,0.1); border-radius: 0.375rem;">
                             {{ form.particularidades.data|safe }}
                         </div>
                         {{ form.particularidades(id="particularidades", type="hidden") }}
@@ -170,8 +170,8 @@
 }
 
 .btn-warning:hover {
-    background-color: #cf661f;
-    border-color: #cf661f;
+    background-color: #0b288b;
+    border-color: #0b288b;
     color: white;
 }
 
@@ -185,25 +185,21 @@
 }
 
 .ql-toolbar {
-    border-top: 1px solid #dee2e6;
-    border-left: 1px solid #dee2e6;
-    border-right: 1px solid #dee2e6;
+    border-top: 1px solid rgba(0,0,0,0.1);
+    border-left: 1px solid rgba(0,0,0,0.1);
+    border-right: 1px solid rgba(0,0,0,0.1);
     border-top-left-radius: 0.375rem;
     border-top-right-radius: 0.375rem;
 }
 
 .ql-container {
-    border-bottom: 1px solid #dee2e6;
-    border-left: 1px solid #dee2e6;
-    border-right: 1px solid #dee2e6;
+    border-bottom: 1px solid rgba(0,0,0,0.1);
+    border-left: 1px solid rgba(0,0,0,0.1);
+    border-right: 1px solid rgba(0,0,0,0.1);
     border-bottom-left-radius: 0.375rem;
     border-bottom-right-radius: 0.375rem;
 }
 
-.form-control.is-valid {
-    border-color: #28a745;
-    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='m2.3 6.73.13-.13 4-4c.1-.1.26-.1.36 0l.1.1c.1.1.1.25 0 .35L2.85 7.09c-.1.1-.26.1-.36 0L.85 5.45c-.1-.1-.1-.26 0-.36l.1-.1c.1-.1.26-.1.36 0l1 1z'/%3e%3c/svg%3e");
-}
 
 @media (max-width: 768px) {
     .container {
@@ -301,7 +297,7 @@ document.addEventListener("DOMContentLoaded", function () {
             }).catch(error => {
                 console.error(error);
                 quill.deleteText(range.index, 'Carregando imagem...'.length);
-                quill.insertText(range.index, '[Erro ao carregar imagem]', 'color', 'red');
+                quill.insertText(range.index, '[Erro ao carregar imagem]', 'color', '#e87429');
             });
         }
     });

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -242,7 +242,7 @@
     </div>
 
     <div class="card shadow-lg mb-5" id="pessoal">
-        <div class="card-header text-white py-3" style="background-color: #6f42c1;">
+        <div class="card-header text-white py-3" style="background-color: #0b288b;">
             <h3 class="mb-0 fw-semibold">
                 <i class="bi bi-people me-2"></i>Departamento Pessoal
             </h3>
@@ -318,7 +318,7 @@
 
                 <!-- Botão de envio -->
                 <div class="d-flex justify-content-center mt-4 pt-3 border-top">
-                    <button type="submit" class="btn px-5" style="background-color: #6f42c1; border-color: #6f42c1; color: white;">
+                    <button type="submit" class="btn px-5" style="background-color: #0b288b; border-color: #0b288b; color: white;">
                         <i class="bi bi-check-lg me-2"></i>Salvar Departamento Pessoal
                     </button>
                 </div>
@@ -504,7 +504,7 @@ document.addEventListener("DOMContentLoaded", function () {
             const formCheck = checkbox.closest('.form-check');
             if (formCheck) {
                 formCheck.style.fontWeight = isChecked ? '600' : 'normal';
-                formCheck.style.color = isChecked ? '#0558c5' : '';
+                formCheck.style.color = isChecked ? '#0b288b' : '';
             }
         }
         checkbox.addEventListener('change', updateStyle);

--- a/app/templates/empresas/editar_empresa.html
+++ b/app/templates/empresas/editar_empresa.html
@@ -1050,7 +1050,7 @@ document.addEventListener("DOMContentLoaded", function () {
         input.addEventListener('change', function() {
             if (this.checked) {
                 this.closest('.form-check').style.fontWeight = '600';
-                this.closest('.form-check').style.color = '#0558c5';
+                this.closest('.form-check').style.color = '#0b288b';
             } else {
                 this.closest('.form-check').style.fontWeight = 'normal';
                 this.closest('.form-check').style.color = '';
@@ -1059,7 +1059,7 @@ document.addEventListener("DOMContentLoaded", function () {
         
         if (input.checked) {
             input.closest('.form-check').style.fontWeight = '600';
-            input.closest('.form-check').style.color = '#0558c5';
+            input.closest('.form-check').style.color = '#0b288b';
         }
     });
 

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -363,7 +363,7 @@
     <div id="pessoal">
         {% if pessoal %}
             <div class="card shadow-lg mb-5">
-                <div class="card-header text-white py-3" style="background-color: #f39c12;">
+                <div class="card-header text-white py-3" style="background-color: #e87429;">
                     <div class="d-flex justify-content-between align-items-center">
                         <h3 class="mb-0 fw-semibold"><i class="bi bi-people me-2"></i>Departamento Pessoal</h3>
                         {% if pessoal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ pessoal.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
@@ -441,7 +441,7 @@
             </div>
         {% else %}
             <div class="card shadow-lg mb-5 border-warning">
-                <div class="card-header text-white py-3" style="background-color: #f39c12;"><h3 class="mb-0 fw-semibold"><i class="bi bi-people me-2"></i>Departamento Pessoal</h3></div>
+                <div class="card-header text-white py-3" style="background-color: #e87429;"><h3 class="mb-0 fw-semibold"><i class="bi bi-people me-2"></i>Departamento Pessoal</h3></div>
                 <div class="card-body p-4 text-center"><div class="py-5"><i class="bi bi-exclamation-triangle-fill fs-1 text-warning mb-3"></i><h5 class="text-muted">Departamento Pessoal não configurado</h5><p class="text-muted mb-4">Este departamento ainda não foi configurado.</p><a href="{{ url_for('editar_empresa', id=empresa.id) }}#pessoal" class="btn btn-warning"><i class="bi bi-plus-circle me-2"></i>Configurar</a></div></div>
             </div>
         {% endif %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -16,9 +16,9 @@
     <style>
         /* Estes estilos seriam idealmente movidos para styles.css */
         body {
-            background-color: #f0f2f5; /* Cor de fundo da página */
+            background-color: #fff; /* Cor de fundo da página */
             font-family: 'Inter', sans-serif; /* Consistente com base.html */
-            color: #333; /* Cor padrão do texto */
+            color: #000; /* Cor padrão do texto */
         }
 
         .header-bg-primary {
@@ -49,7 +49,7 @@
         }
 
         .action-btn .btn:hover {
-            background-color: #cf661f; /* Laranja um pouco mais escuro no hover */
+            background-color: #0b288b; /* Hover usando cor base */
         }
     </style>
 


### PR DESCRIPTION
## Summary
- standardize layout colors with new blue (#0b288b) and orange (#e87429) palette
- adjust base template variables and buttons to rely on the new scheme
- refresh home and reports pages for consistent theming

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b9dbb4aec8330865987c80829f40e