### PR TITLE
Add search bar for company listing

### DIFF
--- a/app/templates/empresas/listar.html
+++ b/app/templates/empresas/listar.html
@@ -35,6 +35,14 @@
         {% endif %}
     {% endwith %}
 
+    <!-- Barra de Pesquisa -->
+    <form method="GET" class="d-flex mb-3">
+        <input type="text" name="q" class="form-control me-2" placeholder="Buscar empresa" value="{{ search or '' }}">
+        <button class="btn btn-outline-secondary" type="submit">
+            <i class="bi bi-search"></i>
+        </button>
+    </form>
+
     <!-- Tabela de Empresas -->
     <div class="card shadow-sm">
         <div class="card-body p-0">


### PR DESCRIPTION
## Summary
- add filtering logic for company list using query parameter
- show search bar to filter companies by code or name

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689c854711ac8330b07a1c03fa1fddb5

## Summary by Sourcery

Implement server-side filtering on the company list by company code or name and expose it through a search bar in the UI.

New Features:
- Filter company listings by code or name using a 'q' query parameter
- Add a search bar to the company listing template for entering search terms