### PR TITLE
Oculta campo extra de particularidades

### DIFF
--- a/app/templates/departamentos/cadastrar.html
+++ b/app/templates/departamentos/cadastrar.html
@@ -32,7 +32,7 @@
                         <div id="editor" style="height: 300px; border: 1px solid #dee2e6; border-radius: 0.375rem;">
                             {{ form.particularidades.data|safe }}
                         </div>
-                        {{ form.particularidades(id="particularidades", type="hidden") }}
+                        {{ form.particularidades(id="particularidades", style="display:none;") }}
                         <small class="text-muted">
                             <i class="bi bi-info-circle me-1"></i>
                             Use o editor para adicionar texto formatado, listas e imagens específicas deste departamento

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -166,7 +166,7 @@
                         <div id="editor" style="height: 200px; border: 1px solid #dee2e6; border-radius: 0.375rem;">
                             {{ form.particularidades.data|safe }}
                         </div>
-                        {{ form.particularidades(id="particularidades", type="hidden") }}
+                        {{ form.particularidades(id="particularidades", style="display:none;") }}
                         <small class="text-muted">
                             <i class="bi bi-info-circle me-1"></i>
                             Use o editor para adicionar texto formatado, listas e fazer upload de imagens. Você também pode colar imagens com <strong>Ctrl+V</strong>

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -160,7 +160,7 @@
                         <div id="editor" style="height: 250px; border: 1px solid #dee2e6; border-radius: 0.375rem;">
                             {{ form.particularidades.data|safe }}
                         </div>
-                        {{ form.particularidades_texto(id="particularidades", type="hidden") }}
+                        {{ form.particularidades_texto(id="particularidades", style="display:none;") }}
                         <small class="text-muted">
                             <i class="bi bi-info-circle me-1"></i>
                             Use o editor para adicionar texto formatado, listas e fazer upload de imagens. Você também pode colar imagens com <strong>Ctrl+V</strong>

--- a/app/templates/departamentos/cadastrar_pessoal.html
+++ b/app/templates/departamentos/cadastrar_pessoal.html
@@ -82,7 +82,7 @@
                         <div id="editor" style="height: 250px; border: 1px solid #dee2e6; border-radius: 0.375rem;">
                             {{ form.particularidades.data|safe }}
                         </div>
-                        {{ form.particularidades(id="particularidades", type="hidden") }}
+                        {{ form.particularidades(id="particularidades", style="display:none;") }}
                         <small class="text-muted">
                             <i class="bi bi-info-circle me-1"></i>
                             Use o editor para adicionar texto formatado, listas e fazer upload de imagens. Você também pode colar imagens com <strong>Ctrl+V</strong>

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -124,7 +124,7 @@
                 <div class="row g-4 mb-4">
                     <div class="col-12">
                         <div id="editor-fiscal" style="height: 250px;"></div>
-                        {{ fiscal_form.particularidades_texto(id="particularidades-fiscal", type="hidden") }}
+                        {{ fiscal_form.particularidades_texto(id="particularidades-fiscal", style="display:none;") }}
                         <input type="file" id="image-input-fiscal" accept="image/*" style="display: none;">
                     </div>
                 </div>
@@ -216,7 +216,7 @@
                 <div class="row g-4 mb-4">
                     <div class="col-12">
                          <div id="editor-contabil" style="height: 250px;"></div>
-                         {{ contabil_form.particularidades_texto(id="particularidades-contabil", type="hidden") }}
+                         {{ contabil_form.particularidades_texto(id="particularidades-contabil", style="display:none;") }}
                          <input type="file" id="image-input-contabil" accept="image/*" style="display: none;">
                     </div>
                 </div>
@@ -280,7 +280,7 @@
                 <div class="row g-4 mb-4">
                     <div class="col-12">
                         <div id="editor-pessoal" style="height: 250px;"></div>
-                        {{ pessoal_form.particularidades_texto(id="particularidades-pessoal", type="hidden") }}
+                        {{ pessoal_form.particularidades_texto(id="particularidades-pessoal", style="display:none;") }}
                         <input type="file" id="image-input-pessoal" accept="image/*" style="display: none;">
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- corrige visibilidade do campo `particularidades` trocando `type="hidden"` por estilo `display:none`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c87733910833093a07ff52091075d

## Summary by Sourcery

Bug Fixes:
- Replace type="hidden" with style="display:none;" for particularidades fields in all department and empresa templates