### PR TITLE
Add address field for fiscal department contacts

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -294,6 +294,9 @@ def editar_empresa(id):
                     contatos_list = []
             else:
                 contatos_list = []
+            for c in contatos_list:
+                if isinstance(c, dict) and 'valor' in c and 'endereco' not in c:
+                    c['endereco'] = c.pop('valor')
             fiscal_form.contatos_json.data = json.dumps(contatos_list)
             
         if contabil:
@@ -382,6 +385,9 @@ def visualizar_empresa(id):
             contatos_list = []
     else:
         contatos_list = []
+    for c in contatos_list:
+        if isinstance(c, dict) and 'valor' in c and 'endereco' not in c:
+            c['endereco'] = c.pop('valor')
 
     # fiscal_view: garante objeto mesmo quando fiscal é None
     if fiscal is None:
@@ -435,6 +441,9 @@ def gerenciar_departamentos(empresa_id):
                 contatos_list = []
         else:
             contatos_list = []
+        for c in contatos_list:
+            if isinstance(c, dict) and 'valor' in c and 'endereco' not in c:
+                c['endereco'] = c.pop('valor')
         fiscal_form.contatos_json.data = json.dumps(contatos_list)
         
         contabil_form = DepartamentoContabilForm(obj=contabil)

--- a/app/forms.py
+++ b/app/forms.py
@@ -108,10 +108,10 @@ class DepartamentoFiscalForm(DepartamentoForm):
         ('', 'Selecione'), ('Digital', 'Digital'), ('Fisico', 'Físico'), ('Digital e Físico', 'Digital e Físico')
     ], validators=[Optional()])
     envio_digital = SelectMultipleField('Envio Digital', choices=[
-        ('email', 'Email'), ('whatsapp', 'Whatsapp'), ('skype', 'Skype'), ('acessorias', 'Acessórias')
+        ('email', 'Email'), ('whatsapp', 'Whatsapp'), ('acessorias', 'Acessórias')
     ], validators=[Optional()])
     envio_digital_fisico = SelectMultipleField('Envio Digital e Físico', choices=[
-        ('email', 'Email'), ('whatsapp', 'Whatsapp'), ('skype', 'Skype'), 
+        ('email', 'Email'), ('whatsapp', 'Whatsapp'),
         ('acessorias', 'Acessórias'), ('malote', 'Malote')], validators=[Optional()])
     observacao_movimento = TextAreaField('Observação', validators=[Optional()])
     contatos_json = HiddenField('Contatos', validators=[Optional()])
@@ -126,10 +126,10 @@ class DepartamentoContabilForm(DepartamentoForm):
         ('', 'Selecione'), ('Digital', 'Digital'), ('Fisico', 'Físico'), ('Digital e Físico', 'Digital e Físico')
     ], validators=[Optional()])
     envio_digital = SelectMultipleField('Envio Digital', choices=[
-        ('email', 'Email'), ('whatsapp', 'Whatsapp'), ('skype', 'Skype'), ('acessorias', 'Acessórias')
+        ('email', 'Email'), ('whatsapp', 'Whatsapp'), ('acessorias', 'Acessórias')
     ], validators=[Optional()])
     envio_digital_fisico = SelectMultipleField('Envio Digital e Físico', choices=[
-        ('email', 'Email'), ('whatsapp', 'Whatsapp'), ('skype', 'Skype'), 
+        ('email', 'Email'), ('whatsapp', 'Whatsapp'),
         ('acessorias', 'Acessórias'), ('malote', 'Malote')], validators=[Optional()])
     observacao_movimento = TextAreaField('Observação Movimento', validators=[Optional()])
     controle_relatorios = SelectMultipleField('Controle por Relatórios', choices=[

--- a/app/static/javascript/contatos.js
+++ b/app/static/javascript/contatos.js
@@ -11,31 +11,35 @@ function setupContatos(containerId, addBtnId, hiddenInputId) {
   function render() {
     container.innerHTML = '';
     contatos.forEach((c, idx) => {
-      const row = document.createElement('div');
-      row.className = 'row mb-2';
+      const wrapper = document.createElement('div');
+      wrapper.className = 'mb-3 contato-item';
       const endereco = c.endereco || c.valor || '';
       const nome = c.nome || '';
-      row.innerHTML = `
-        <div class="col-md-4 mb-1 mb-md-0">
-          <input type="text" class="form-control contato-nome" value="${nome}" placeholder="Nome do contato">
+      wrapper.innerHTML = `
+        <div class="row g-2">
+          <div class="col-md-5 mb-1 mb-md-0">
+            <input type="text" class="form-control contato-nome" value="${nome}" placeholder="Nome do contato">
+          </div>
+          <div class="col-md-5 mb-1 mb-md-0">
+            <select class="form-select contato-tipo">
+              <option value="email" ${c.tipo === 'email' ? 'selected' : ''}>E-mail</option>
+              <option value="telefone" ${c.tipo === 'telefone' ? 'selected' : ''}>Telefone</option>
+              <option value="whatsapp" ${c.tipo === 'whatsapp' ? 'selected' : ''}>Whatsapp</option>
+              <option value="skype" ${c.tipo === 'skype' ? 'selected' : ''}>Skype</option>
+              <option value="acessorias" ${c.tipo === 'acessorias' ? 'selected' : ''}>Acessórias</option>
+            </select>
+          </div>
+          <div class="col-md-2 d-flex align-items-center">
+            <button type="button" class="btn btn-danger btn-sm w-100" data-idx="${idx}">Remover</button>
+          </div>
         </div>
-        <div class="col-md-4 mb-1 mb-md-0">
-          <select class="form-select contato-tipo">
-            <option value="email" ${c.tipo === 'email' ? 'selected' : ''}>E-mail</option>
-            <option value="telefone" ${c.tipo === 'telefone' ? 'selected' : ''}>Telefone</option>
-            <option value="whatsapp" ${c.tipo === 'whatsapp' ? 'selected' : ''}>Whatsapp</option>
-            <option value="skype" ${c.tipo === 'skype' ? 'selected' : ''}>Skype</option>
-            <option value="acessorias" ${c.tipo === 'acessorias' ? 'selected' : ''}>Acessórias</option>
-          </select>
-        </div>
-        <div class="col-md-3 mb-1 mb-md-0">
-          <input type="text" class="form-control contato-endereco" value="${endereco}" placeholder="Endereço do contato">
-        </div>
-        <div class="col-md-1 d-flex align-items-center">
-          <button type="button" class="btn btn-danger btn-sm" data-idx="${idx}">Remover</button>
+        <div class="row g-2 mt-1">
+          <div class="col-12">
+            <input type="text" class="form-control contato-endereco" value="${endereco}" placeholder="Endereço do contato">
+          </div>
         </div>`;
-      container.appendChild(row);
-      setupEnderecoField(row);
+      container.appendChild(wrapper);
+      setupEnderecoField(wrapper);
     });
     bindRemove();
     updateHidden();
@@ -50,10 +54,10 @@ function setupContatos(containerId, addBtnId, hiddenInputId) {
     });
   }
   function updateHidden() {
-    container.querySelectorAll('.row').forEach((row, idx) => {
-      const nome = row.querySelector('.contato-nome').value;
-      const tipo = row.querySelector('.contato-tipo').value;
-      const endereco = row.querySelector('.contato-endereco').value;
+    container.querySelectorAll('.contato-item').forEach((item, idx) => {
+      const nome = item.querySelector('.contato-nome').value;
+      const tipo = item.querySelector('.contato-tipo').value;
+      const endereco = item.querySelector('.contato-endereco').value;
       contatos[idx] = { nome, tipo, endereco };
     });
     hiddenInput.value = JSON.stringify(contatos);

--- a/app/static/javascript/contatos.js
+++ b/app/static/javascript/contatos.js
@@ -13,6 +13,7 @@ function setupContatos(containerId, addBtnId, hiddenInputId) {
     contatos.forEach((c, idx) => {
       const row = document.createElement('div');
       row.className = 'row mb-2';
+      const endereco = c.endereco || c.valor || '';
       row.innerHTML = `
         <div class="col-md-5">
           <select class="form-select contato-tipo">
@@ -24,7 +25,7 @@ function setupContatos(containerId, addBtnId, hiddenInputId) {
           </select>
         </div>
         <div class="col-md-5">
-          <input type="text" class="form-control contato-valor" value="${c.valor || ''}" placeholder="Informação do contato">
+          <input type="text" class="form-control contato-endereco" value="${endereco}" placeholder="Endereço do contato">
         </div>
         <div class="col-md-2 d-flex align-items-center">
           <button type="button" class="btn btn-danger btn-sm" data-idx="${idx}">Remover</button>
@@ -46,13 +47,13 @@ function setupContatos(containerId, addBtnId, hiddenInputId) {
   function updateHidden() {
     container.querySelectorAll('.row').forEach((row, idx) => {
       const tipo = row.querySelector('.contato-tipo').value;
-      const valor = row.querySelector('.contato-valor').value;
-      contatos[idx] = { tipo, valor };
+      const endereco = row.querySelector('.contato-endereco').value;
+      contatos[idx] = { tipo, endereco };
     });
     hiddenInput.value = JSON.stringify(contatos);
   }
   addBtn.addEventListener('click', function () {
-    contatos.push({ tipo: 'email', valor: '' });
+    contatos.push({ tipo: 'email', endereco: '' });
     render();
   });
   container.addEventListener('change', updateHidden);

--- a/app/static/javascript/contatos.js
+++ b/app/static/javascript/contatos.js
@@ -25,7 +25,6 @@ function setupContatos(containerId, addBtnId, hiddenInputId) {
               <option value="email" ${c.tipo === 'email' ? 'selected' : ''}>E-mail</option>
               <option value="telefone" ${c.tipo === 'telefone' ? 'selected' : ''}>Telefone</option>
               <option value="whatsapp" ${c.tipo === 'whatsapp' ? 'selected' : ''}>Whatsapp</option>
-              <option value="skype" ${c.tipo === 'skype' ? 'selected' : ''}>Skype</option>
               <option value="acessorias" ${c.tipo === 'acessorias' ? 'selected' : ''}>Acessórias</option>
             </select>
           </div>
@@ -88,7 +87,7 @@ function setupContatos(containerId, addBtnId, hiddenInputId) {
         enderecoInput.type = 'email';
       } else if (tipo === 'telefone' || tipo === 'whatsapp') {
         enderecoInput.type = 'tel';
-        enderecoInput.pattern = '\\d{10,11}';
+        enderecoInput.pattern = '\\(\\d{2}\\)\\s?\\d{4,5}-\\d{4}';
         handlePhoneInput();
         enderecoInput.addEventListener('input', handlePhoneInput);
       }

--- a/app/static/javascript/contatos.js
+++ b/app/static/javascript/contatos.js
@@ -8,56 +8,97 @@ function setupContatos(containerId, addBtnId, hiddenInputId) {
   } catch (e) {
     contatos = [];
   }
+
   function render() {
     container.innerHTML = '';
     contatos.forEach((c, idx) => {
       const wrapper = document.createElement('div');
       wrapper.className = 'mb-3 contato-item';
-      const endereco = c.endereco || c.valor || '';
       const nome = c.nome || '';
+      const meios = Array.isArray(c.meios) && c.meios.length ? c.meios : [{ tipo: 'email', endereco: '' }];
       wrapper.innerHTML = `
         <div class="row g-2">
-          <div class="col-md-5 mb-1 mb-md-0">
+          <div class="col-md-10 mb-1 mb-md-0">
             <input type="text" class="form-control contato-nome" value="${nome}" placeholder="Nome do contato">
           </div>
-          <div class="col-md-5 mb-1 mb-md-0">
-            <select class="form-select contato-tipo">
-              <option value="email" ${c.tipo === 'email' ? 'selected' : ''}>E-mail</option>
-              <option value="telefone" ${c.tipo === 'telefone' ? 'selected' : ''}>Telefone</option>
-              <option value="whatsapp" ${c.tipo === 'whatsapp' ? 'selected' : ''}>Whatsapp</option>
-              <option value="acessorias" ${c.tipo === 'acessorias' ? 'selected' : ''}>Acessórias</option>
-            </select>
-          </div>
           <div class="col-md-2 d-flex align-items-center">
-            <button type="button" class="btn btn-danger btn-sm w-100" data-idx="${idx}">Remover</button>
+            <button type="button" class="btn btn-danger btn-sm w-100 remove-contato" data-idx="${idx}">Remover</button>
           </div>
         </div>
-        <div class="row g-2 mt-1">
-          <div class="col-12">
-            <input type="text" class="form-control contato-endereco" value="${endereco}" placeholder="Endereço do contato">
-          </div>
-        </div>`;
+        <div class="meios-container"></div>
+        <button type="button" class="btn btn-secondary btn-sm mt-2 add-meio" data-idx="${idx}">Adicionar contato</button>`;
       container.appendChild(wrapper);
-      setupEnderecoField(wrapper);
+
+      const meiosContainer = wrapper.querySelector('.meios-container');
+      meios.forEach((m, mIdx) => {
+        const meioDiv = document.createElement('div');
+        meioDiv.className = 'meio-item mt-2';
+        const endereco = m.endereco || '';
+        meioDiv.innerHTML = `
+          <div class="row g-2">
+            <div class="col-md-5 mb-1 mb-md-0">
+              <select class="form-select contato-tipo">
+                <option value="email" ${m.tipo === 'email' ? 'selected' : ''}>E-mail</option>
+                <option value="telefone" ${m.tipo === 'telefone' ? 'selected' : ''}>Telefone</option>
+                <option value="whatsapp" ${m.tipo === 'whatsapp' ? 'selected' : ''}>Whatsapp</option>
+                <option value="acessorias" ${m.tipo === 'acessorias' ? 'selected' : ''}>Acessórias</option>
+              </select>
+            </div>
+            <div class="col-md-2 d-flex align-items-center">
+              <button type="button" class="btn btn-danger btn-sm w-100 remove-meio" data-cidx="${idx}" data-midx="${mIdx}">Remover</button>
+            </div>
+          </div>
+          <div class="row g-2 mt-1">
+            <div class="col-12">
+              <input type="text" class="form-control contato-endereco" value="${endereco}" placeholder="Endereço do contato">
+            </div>
+          </div>`;
+        meiosContainer.appendChild(meioDiv);
+        setupEnderecoField(meioDiv);
+      });
     });
-    bindRemove();
+    bindActions();
     updateHidden();
   }
-  function bindRemove() {
-    container.querySelectorAll('button[data-idx]').forEach(btn => {
+
+  function bindActions() {
+    container.querySelectorAll('.remove-contato').forEach(btn => {
       btn.addEventListener('click', function () {
         const index = this.getAttribute('data-idx');
         contatos.splice(index, 1);
         render();
       });
     });
+    container.querySelectorAll('.add-meio').forEach(btn => {
+      btn.addEventListener('click', function () {
+        const index = this.getAttribute('data-idx');
+        contatos[index].meios.push({ tipo: 'email', endereco: '' });
+        render();
+      });
+    });
+    container.querySelectorAll('.remove-meio').forEach(btn => {
+      btn.addEventListener('click', function () {
+        const cIdx = this.getAttribute('data-cidx');
+        const mIdx = this.getAttribute('data-midx');
+        contatos[cIdx].meios.splice(mIdx, 1);
+        if (contatos[cIdx].meios.length === 0) {
+          contatos[cIdx].meios.push({ tipo: 'email', endereco: '' });
+        }
+        render();
+      });
+    });
   }
+
   function updateHidden() {
     container.querySelectorAll('.contato-item').forEach((item, idx) => {
       const nome = item.querySelector('.contato-nome').value;
-      const tipo = item.querySelector('.contato-tipo').value;
-      const endereco = item.querySelector('.contato-endereco').value;
-      contatos[idx] = { nome, tipo, endereco };
+      const meios = [];
+      item.querySelectorAll('.meio-item').forEach(meio => {
+        const tipo = meio.querySelector('.contato-tipo').value;
+        const endereco = meio.querySelector('.contato-endereco').value;
+        meios.push({ tipo, endereco });
+      });
+      contatos[idx] = { nome, meios };
     });
     hiddenInput.value = JSON.stringify(contatos);
   }
@@ -98,7 +139,7 @@ function setupContatos(containerId, addBtnId, hiddenInputId) {
   }
 
   addBtn.addEventListener('click', function () {
-    contatos.push({ nome: '', tipo: 'email', endereco: '' });
+    contatos.push({ nome: '', meios: [{ tipo: 'email', endereco: '' }] });
     render();
   });
 

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -110,7 +110,7 @@
                         <label class="form-label fw-semibold">Contatos</label>
                         <div id="contatos-container"></div>
                         <button type="button" class="btn btn-outline-dept-blue btn-sm mt-2" id="add-contato">
-                            <i class="bi bi-plus-circle"></i> Adicionar Contato
+                            <i class="bi bi-plus-circle"></i> Adicionar Pessoa
                         </button>
                         {{ fiscal_form.contatos_json(id='contatos_json') }}
                     </div>

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -202,7 +202,7 @@
                                 {% if fiscal.contatos_list %}
                                     <ul class="list-unstyled mb-0">
                                         {% for contato in fiscal.contatos_list %}
-                                            <li><span class="fw-semibold">{{ contato.tipo|capitalize }}:</span> {{ contato.valor }}</li>
+                                            <li><span class="fw-semibold">{{ contato.tipo|capitalize }}:</span> {{ contato.endereco }}</li>
                                         {% endfor %}
                                     </ul>
                                 {% else %}

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -202,9 +202,12 @@
                                 {% if fiscal.contatos_list %}
                                     <ul class="list-unstyled mb-0">
                                         {% for contato in fiscal.contatos_list %}
-                                            <li>
-                                                {% if contato.nome %}<span class="fw-semibold">{{ contato.nome }}</span> - {% endif %}
-                                                <span class="fw-semibold">{{ contato.tipo|capitalize }}:</span> {{ contato.endereco }}
+                                            <li class="mb-2">
+                                                <div>
+                                                    {% if contato.nome %}<span class="fw-semibold">{{ contato.nome }}</span> - {% endif %}
+                                                    <span class="fw-semibold">{{ contato.tipo|capitalize }}</span>
+                                                </div>
+                                                <div>{{ contato.endereco }}</div>
                                             </li>
                                         {% endfor %}
                                     </ul>

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -202,7 +202,10 @@
                                 {% if fiscal.contatos_list %}
                                     <ul class="list-unstyled mb-0">
                                         {% for contato in fiscal.contatos_list %}
-                                            <li><span class="fw-semibold">{{ contato.tipo|capitalize }}:</span> {{ contato.endereco }}</li>
+                                            <li>
+                                                {% if contato.nome %}<span class="fw-semibold">{{ contato.nome }}</span> - {% endif %}
+                                                <span class="fw-semibold">{{ contato.tipo|capitalize }}:</span> {{ contato.endereco }}
+                                            </li>
                                         {% endfor %}
                                     </ul>
                                 {% else %}

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -203,11 +203,10 @@
                                     <ul class="list-unstyled mb-0">
                                         {% for contato in fiscal.contatos_list %}
                                             <li class="mb-2">
-                                                <div>
-                                                    {% if contato.nome %}<span class="fw-semibold">{{ contato.nome }}</span> - {% endif %}
-                                                    <span class="fw-semibold">{{ contato.tipo|capitalize }}</span>
-                                                </div>
-                                                <div>{{ contato.endereco }}</div>
+                                                {% if contato.nome %}<div class="fw-semibold">{{ contato.nome }}</div>{% endif %}
+                                                {% for meio in contato.meios %}
+                                                    <div><span class="fw-semibold">{{ meio.tipo|capitalize }}</span> - {{ meio.endereco }}</div>
+                                                {% endfor %}
                                             </li>
                                         {% endfor %}
                                     </ul>


### PR DESCRIPTION
## Summary
- allow contact entries to store an explicit address value
- show contact address in company view
- normalize existing contact data on load

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689c8b7f71f08330984df7fbfd51ae7a

## Summary by Sourcery

Introduce an explicit address field for fiscal department contacts by migrating legacy 'valor' entries to 'endereco' and updating server-side loading, front-end logic, and templates to use the new property

Enhancements:
- Add 'endereco' property and normalize existing 'valor' values in routes for company and department views
- Update JavaScript to render, edit, and serialize the new contato-endereco field instead of 'valor'
- Adjust company view template to display contact addresses from the 'endereco' field instead of 'valor'