### PR TITLE
Align prefeitura access view with cadastro styling

### DIFF
--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -171,17 +171,25 @@
                     <div class="col-lg-6 col-md-12">
                         <div class="info-group">
                             <h6 class="text-dept-blue mb-3 border-bottom pb-2"><i class="bi bi-building me-2"></i>Acesso à Prefeitura</h6>
-                            <div class="info-item">
-                                <label class="info-label">Link da Prefeitura</label>
-                                <div class="info-value">{% if fiscal.link_prefeitura and fiscal.link_prefeitura.strip() %}<a href="{{ fiscal.link_prefeitura }}" target="_blank" class="text-decoration-none"><i class="bi bi-link-45deg me-1 text-dept-blue"></i><span class="text-primary">{{ fiscal.link_prefeitura[:60] }}{% if fiscal.link_prefeitura|length > 60 %}...{% endif %}</span><i class="bi bi-box-arrow-up-right ms-1"></i></a>{% else %}<span class="text-muted">Não informado</span>{% endif %}</div>
-                            </div>
-                            <div class="info-item">
-                                <label class="info-label">Usuário da Prefeitura</label>
-                                <div class="info-value">{% if fiscal.usuario_prefeitura %}<div class="font-monospace clickable-copy border rounded p-2 bg-light"><i class="bi bi-person me-2 text-dept-blue"></i>{{ fiscal.usuario_prefeitura }}<i class="bi bi-clipboard ms-2 text-muted" title="Clique para copiar"></i></div>{% else %}<span class="text-muted">Não informado</span>{% endif %}</div>
-                            </div>
-                            <div class="info-item">
-                                <label class="info-label">Senha da Prefeitura</label>
-                                <div class="info-value centered">{% if fiscal.senha_prefeitura and fiscal.senha_prefeitura.strip() %}<span class="password-field" data-password="{{ fiscal.senha_prefeitura }}"><div class="d-flex align-items-center border rounded p-2 bg-light"><i class="bi bi-key me-2 text-dept-blue"></i><span class="password-hidden font-monospace">••••••••</span><button type="button" class="btn btn-sm btn-outline-dept-blue ms-2 toggle-password"><i class="bi bi-eye"></i></button></div></span>{% else %}<span class="text-muted">Não informada</span>{% endif %}</div>
+                            <div class="row g-4">
+                                <div class="col-12">
+                                    <div class="info-item">
+                                        <label class="info-label">Link da Prefeitura</label>
+                                        <div class="info-value">{% if fiscal.link_prefeitura and fiscal.link_prefeitura.strip() %}<a href="{{ fiscal.link_prefeitura }}" target="_blank" class="text-decoration-none"><i class="bi bi-link-45deg me-1 text-dept-blue"></i><span class="text-primary">{{ fiscal.link_prefeitura[:60] }}{% if fiscal.link_prefeitura|length > 60 %}...{% endif %}</span><i class="bi bi-box-arrow-up-right ms-1"></i></a>{% else %}<span class="text-muted">Não informado</span>{% endif %}</div>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="info-item">
+                                        <label class="info-label">Usuário da Prefeitura</label>
+                                        <div class="info-value">{% if fiscal.usuario_prefeitura %}<div class="font-monospace clickable-copy border rounded p-2 bg-light"><i class="bi bi-person me-2 text-dept-blue"></i>{{ fiscal.usuario_prefeitura }}<i class="bi bi-clipboard ms-2 text-muted" title="Clique para copiar"></i></div>{% else %}<span class="text-muted">Não informado</span>{% endif %}</div>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="info-item">
+                                        <label class="info-label">Senha da Prefeitura</label>
+                                        <div class="info-value centered">{% if fiscal.senha_prefeitura and fiscal.senha_prefeitura.strip() %}<span class="password-field" data-password="{{ fiscal.senha_prefeitura }}"><div class="d-flex align-items-center border rounded p-2 bg-light"><i class="bi bi-key me-2 text-dept-blue"></i><span class="password-hidden font-monospace">••••••••</span><button type="button" class="btn btn-sm btn-outline-dept-blue ms-2 toggle-password"><i class="bi bi-eye"></i></button></div></span>{% else %}<span class="text-muted">Não informada</span>{% endif %}</div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Align 'Acesso à Prefeitura' section in company view with layout used during cadastro

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689cb9b9d33c833086a034ec974e9ecc