### PR TITLE
Remove unused accounting observation fields

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -276,8 +276,6 @@ def processar_dados_contabil(request):
     descricao = request.form.get('descricao')
     metodo_importacao = request.form.get('metodo_importacao')
     forma_movimento = request.form.get('forma_movimento')
-    observacao_movimento = request.form.get('observacao_movimento')
-    observacao_controle_relatorios = request.form.get('observacao_controle_relatorios')
     particularidades = request.form.get('particularidades')
     envio_digital_json = request.form.get('envio_digital_json', '[]')
     envio_digital = json.loads(envio_digital_json) if envio_digital_json else []    
@@ -293,9 +291,7 @@ def processar_dados_contabil(request):
         'forma_movimento': forma_movimento,
         'envio_digital': envio_digital,
         'envio_digital_fisico': envio_digital_fisico,
-        'observacao_movimento': observacao_movimento,
         'controle_relatorios': controle_relatorios,
-        'observacao_controle_relatorios': observacao_controle_relatorios,
         'particularidades_texto': particularidades
     }
 

--- a/app/forms.py
+++ b/app/forms.py
@@ -129,14 +129,12 @@ class DepartamentoContabilForm(DepartamentoForm):
     envio_digital_fisico = SelectMultipleField('Envio Digital e Físico', choices=[
         ('email', 'Email'), ('whatsapp', 'Whatsapp'),
         ('acessorias', 'Acessórias'), ('malote', 'Malote')], validators=[Optional()])
-    observacao_movimento = TextAreaField('Observação Movimento', validators=[Optional()])
     controle_relatorios = SelectMultipleField('Controle por Relatórios', choices=[
         ('forn_cli_cota_unica', 'Fornecedor e clientes cota única'),
         ('saldo_final_mes', 'Relatório com saldo final do mês'),
         ('adiantamentos', 'Relatório de adiantamentos'), ('contas_pagas', 'Relatório de contas pagas'),
         ('contas_recebidas', 'Relatório de contas recebidas'),
         ('conferir_aplicacao', 'Conferir aplicação')], validators=[Optional()])
-    observacao_controle_relatorios = TextAreaField('Observação Relatórios', validators=[Optional()])
     particularidades_texto = TextAreaField('Particularidades', validators=[Optional()])
 
 class DepartamentoPessoalForm(DepartamentoForm):

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -84,7 +84,6 @@ class Departamento(db.Model):
     observacao_movimento = db.Column(db.String(200))
     metodo_importacao = db.Column(db.String(20))
     controle_relatorios = db.Column(JsonString(255))
-    observacao_controle_relatorios = db.Column(db.String(200))
     contatos = db.Column(JsonString(255))
     data_envio = db.Column(db.String(100))
     registro_funcionarios = db.Column(db.String(200))

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -119,7 +119,7 @@
                 </div>
                 
                 <div class="row g-4 mb-4">
-                    <div class="col-md-6">
+                    <div class="col-12">
                         <label class="form-label fw-semibold">{{ form.controle_relatorios.label.text }}</label>
                         <div class="border rounded p-3 bg-light">
                             <div class="row">
@@ -134,13 +134,6 @@
                             </div>
                         </div>
                     </div>
-                    
-                    <div class="col-md-6">
-                        <div class="form-floating">
-                            {{ form.observacao_controle_relatorios(class="form-control", placeholder="Observação", style="height: 120px") }}
-                            {{ form.observacao_controle_relatorios.label(class="form-label") }}
-                        </div>
-                    </div>
                 </div>
 
                 <div class="row mb-4">
@@ -152,14 +145,7 @@
                 </div>
                 
                 <div class="row g-4 mb-4">
-                    <div class="col-md-6">
-                        <div class="form-floating">
-                            {{ form.observacao_movimento(class="form-control", placeholder="Observação", style="height: 120px") }}
-                            {{ form.observacao_movimento.label(class="form-label") }}
-                        </div>
-                    </div>
-                    
-                    <div class="col-md-6">
+                    <div class="col-12">
                         <label class="form-label fw-semibold">
                             <i class="bi bi-pencil-square me-1"></i>Editor de Particularidades
                         </label>

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -191,7 +191,7 @@
 
                 <h5 class="text-dept-orange border-bottom pb-2 mb-3"><i class="bi bi-file-earmark-text me-2"></i>Controle e Relatórios</h5>
                 <div class="row g-4 mb-4">
-                    <div class="col-md-6">
+                    <div class="col-12">
                         <label class="form-label fw-semibold">{{ contabil_form.controle_relatorios.label.text }}</label>
                         <div class="border rounded p-3 bg-light"><div class="row">
                             {% for value, label in contabil_form.controle_relatorios.choices %}
@@ -209,11 +209,6 @@
                             {% endfor %}
                         </div></div>
                     </div>
-                    <div class="col-md-6"><div class="form-floating">{{ contabil_form.observacao_controle_relatorios(class="form-control", placeholder="Observação", style="height: 100px") }}{{ contabil_form.observacao_controle_relatorios.label }}</div></div>
-                </div>
-
-                <div class="row g-4 mb-4">
-                    <div class="col-12"><div class="form-floating">{{ contabil_form.observacao_movimento(class="form-control", placeholder="Observação do Movimento", style="height: 100px") }}{{ contabil_form.observacao_movimento.label }}</div></div>
                 </div>
 
                 <h5 class="text-dept-orange border-bottom pb-2 mb-3"><i class="bi bi-pencil-square me-2"></i>Particularidades</h5>

--- a/app/templates/empresas/editar_empresa.html
+++ b/app/templates/empresas/editar_empresa.html
@@ -568,7 +568,7 @@
                             {% endif %}
                         </div>
                     </div>
-                    <div class="col-md-6">
+                    <div class="col-12">
                         <label class="form-label fw-semibold">{{ contabil_form.controle_relatorios.label.text }}</label>
                         <div class="border rounded p-3 bg-light">
                             <div class="row">
@@ -597,33 +597,7 @@
 
                 <!-- Observações -->
                 <div class="row g-4 mb-4">
-                    <div class="col-md-6">
-                        <div class="form-floating">
-                            {{ contabil_form.observacao_movimento(class="form-control", placeholder="Observação", style="height: 100px") }}
-                            {{ contabil_form.observacao_movimento.label(class="form-label") }}
-                            {% if contabil_form.observacao_movimento.errors %}
-                                <div class="text-danger mt-1">
-                                    {% for error in contabil_form.observacao_movimento.errors %}
-                                        <small>{{ error }}</small><br>
-                                    {% endfor %}
-                                </div>
-                            {% endif %}
-                        </div>
-                    </div>
-                    <div class="col-md-6">
-                        <div class="form-floating">
-                            {{ contabil_form.observacao_controle_relatorios(class="form-control", placeholder="Observação Controle Relatórios", style="height: 100px") }}
-                            {{ contabil_form.observacao_controle_relatorios.label(class="form-label") }}
-                            {% if contabil_form.observacao_controle_relatorios.errors %}
-                                <div class="text-danger mt-1">
-                                    {% for error in contabil_form.observacao_controle_relatorios.errors %}
-                                        <small>{{ error }}</small><br>
-                                    {% endfor %}
-                                </div>
-                            {% endif %}
-                        </div>
-                    </div>
-                    <div class="col-md-12">
+                    <div class="col-12">
                         <div class="form-floating">
                             {{ contabil_form.particularidades_texto(class="form-control", placeholder="Particularidades", style="height: 100px") }}
                             {{ contabil_form.particularidades_texto.label(class="form-label") }}

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -286,7 +286,7 @@
             </div>
             <div class="card-body p-4">
                 <div class="row g-4">
-                    <div class="col-lg-6 col-md-12">
+                    <div class="col-12">
                         <div class="info-group">
                             <h6 class="text-dept-orange mb-3 border-bottom pb-2"><i class="bi bi-info-circle me-2"></i>Informações Básicas</h6>
                             <div class="info-item">
@@ -296,19 +296,6 @@
                             <div class="info-item">
                                 <label class="info-label">Forma de Movimento</label>
                                 <div class="info-value">{% if contabil.forma_movimento %}<span class="badge bg-dept-orange-subtle fs-6"><i class="bi bi-arrow-left-right me-1 text-dept-orange"></i>{{ contabil.forma_movimento }}</span>{% else %}<span class="text-muted">Não informada</span>{% endif %}</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-md-12">
-                        <div class="info-group">
-                            <h6 class="text-dept-orange mb-3 border-bottom pb-2"><i class="bi bi-chat-square-text me-2"></i>Observações</h6>
-                             <div class="info-item">
-                                <label class="info-label">Observação de Movimento</label>
-                                <div class="info-value">{% if contabil.observacao_movimento %}<div class="border rounded p-3 bg-light"><i class="bi bi-sticky me-2 text-dept-orange"></i>{{ contabil.observacao_movimento }}</div>{% else %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-chat-square fs-3 mb-2"></i><p class="mb-0">Nenhuma observação</p></div>{% endif %}</div>
-                            </div>
-                            <div class="info-item">
-                                <label class="info-label">Observação de Relatórios</label>
-                                <div class="info-value">{% if contabil.observacao_controle_relatorios %}<div class="border rounded p-3 bg-light"><i class="bi bi-file-earmark-text me-2 text-dept-orange"></i>{{ contabil.observacao_controle_relatorios }}</div>{% else %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-file-earmark fs-3 mb-2"></i><p class="mb-0">Nenhuma observação</p></div>{% endif %}</div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- drop movement and report observation inputs from accounting forms and views
- clean up accounting data processing and model accordingly

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_689cc1c27bb08330b96736d204124e65

## Summary by Sourcery

Remove unused accounting observation fields and clean up related code and UI layouts.

Enhancements:
- Remove observacao_movimento and observacao_controle_relatorios fields from forms, request processing, and templates
- Drop the observacao_controle_relatorios column from the accounting model
- Update templates to use full-width columns for control reports and particularidades sections