### PR TITLE
Place movement type selection with shipping options

### DIFF
--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -28,10 +28,6 @@
                         <label class="form-label fw-semibold">{{ form.metodo_importacao.label.text }}</label>
                         {{ form.metodo_importacao(class="form-select") }}
                     </div>
-                    <div class="col-md-6">
-                        <label class="form-label fw-semibold">{{ form.forma_movimento.label.text }}</label>
-                        {{ form.forma_movimento(id="forma_movimento", class="form-select") }}
-                    </div>
                 </div>
 
                 <div class="row mb-4">
@@ -41,7 +37,14 @@
                         </h5>
                     </div>
                 </div>
-                
+
+                <div class="row g-4 mb-4">
+                    <div class="col-md-6">
+                        <label class="form-label fw-semibold">{{ form.forma_movimento.label.text }}</label>
+                        {{ form.forma_movimento(id="forma_movimento", class="form-select") }}
+                    </div>
+                </div>
+
                 <div class="row g-4 mb-4">
                     <div class="col-md-6" id="envio_digital_container">
                         <label class="form-label fw-semibold">{{ form.envio_digital.label.text }}</label>
@@ -58,7 +61,7 @@
                             </div>
                         </div>
                     </div>
-                    
+
                     <div class="col-md-6" id="envio_fisico_container">
                         <label class="form-label fw-semibold">{{ form.envio_fisico.label.text }}</label>
                         <div class="border rounded p-3 bg-light">

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -40,11 +40,6 @@
                             </div>
                         </div>
                     </div>
-                    
-                    <div class="col-md-6">
-                        <label class="form-label fw-semibold">{{ form.forma_movimento.label.text }}</label>
-                        {{ form.forma_movimento(id="forma_movimento", class="form-select") }}
-                    </div>
                 </div>
 
                 <div class="row mb-4">
@@ -72,7 +67,14 @@
                         </h5>
                     </div>
                 </div>
-                
+
+                <div class="row g-4 mb-4">
+                    <div class="col-md-6">
+                        <label class="form-label fw-semibold">{{ form.forma_movimento.label.text }}</label>
+                        {{ form.forma_movimento(id="forma_movimento", class="form-select") }}
+                    </div>
+                </div>
+
                 <div class="row g-4 mb-4">
                     <div class="col-md-6" id="envio_digital_container">
                         <label class="form-label fw-semibold">{{ form.envio_digital.label.text }}</label>
@@ -89,7 +91,7 @@
                             </div>
                         </div>
                     </div>
-                    
+
                     <div class="col-md-6" id="envio_fisico_container">
                         <label class="form-label fw-semibold">{{ form.envio_fisico.label.text }}</label>
                         <div class="border rounded p-3 bg-light">

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -56,10 +56,6 @@
                             {% for value, label in fiscal_form.formas_importacao.choices %}<div class="col-md-6 mb-2"><div class="form-check"><input class="form-check-input" type="checkbox" name="{{ fiscal_form.formas_importacao.name }}" value="{{ value }}" id="fi-{{ loop.index }}" {% if value in (fiscal_form.formas_importacao.data or []) %}checked{% endif %}><label class="form-check-label" for="fi-{{ loop.index }}">{{ label }}</label></div></div>{% endfor %}
                         </div></div>
                     </div>
-                    <div class="col-md-6">
-                        <label class="form-label fw-semibold">{{ fiscal_form.forma_movimento.label.text }}</label>
-                        {{ fiscal_form.forma_movimento(id="fiscal_forma_movimento", class="form-select") }}
-                    </div>
                 </div>
 
                 <h5 class="text-dept-blue border-bottom pb-2 mb-3"><i class="bi bi-building me-2"></i>Acesso à Prefeitura</h5>
@@ -76,7 +72,10 @@
                 <h5 class="text-dept-blue border-bottom pb-2 mb-3"><i class="bi bi-cloud-upload me-2"></i>Envio Digital e Contato</h5>
                 <div class="row g-4 mb-4">
                     <div class="col-md-6">
-                        <div id="fiscal_envio_digital">
+                        <label class="form-label fw-semibold">{{ fiscal_form.forma_movimento.label.text }}</label>
+                        {{ fiscal_form.forma_movimento(id="fiscal_forma_movimento", class="form-select") }}
+
+                        <div id="fiscal_envio_digital" class="mt-3">
                             <label class="form-label fw-semibold">{{ fiscal_form.envio_digital.label.text }}</label>
                             <div class="border rounded p-3 bg-light"><div class="row">
                                 {% for value, label in fiscal_form.envio_digital.choices %}


### PR DESCRIPTION
## Summary
- Move movement type select into shipment section on accounting department form
- Move movement type select into shipment section on fiscal department form
- Align company department page so movement type select sits with shipment options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cebace9e08330a7c46503305cee49