### PR TITLE
Group shipping options with type selection

### DIFF
--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -28,22 +28,23 @@
                         <label class="form-label fw-semibold">{{ form.metodo_importacao.label.text }}</label>
                         {{ form.metodo_importacao(class="form-select") }}
                     </div>
-                    <div class="col-md-6">
-                        <label class="form-label fw-semibold">{{ form.forma_movimento.label.text }}</label>
-                        {{ form.forma_movimento(id="forma_movimento", class="form-select") }}
-                    </div>
                 </div>
 
                 <div class="row mb-4">
                     <div class="col-12">
                         <h5 class="text-primary border-bottom pb-2 mb-3">
-                            <i class="bi bi-cloud-upload me-2"></i>Envio Digital
+                            <i class="bi bi-cloud-upload me-2"></i>Tipo de Envio
                         </h5>
                     </div>
                 </div>
-                
+
                 <div class="row g-4 mb-4">
-                    <div class="col-md-6" id="envio_digital_container">
+                    <div class="col-md-4">
+                        <label class="form-label fw-semibold">{{ form.forma_movimento.label.text }}</label>
+                        {{ form.forma_movimento(id="forma_movimento", class="form-select") }}
+                    </div>
+
+                    <div class="col-md-4" id="envio_digital_container">
                         <label class="form-label fw-semibold">{{ form.envio_digital.label.text }}</label>
                         <div class="border rounded p-3 bg-light">
                             <div class="row">
@@ -58,8 +59,8 @@
                             </div>
                         </div>
                     </div>
-                    
-                    <div class="col-md-6" id="envio_fisico_container">
+
+                    <div class="col-md-4" id="envio_fisico_container">
                         <label class="form-label fw-semibold">{{ form.envio_fisico.label.text }}</label>
                         <div class="border rounded p-3 bg-light">
                             <div class="row">

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -41,10 +41,6 @@
                         </div>
                     </div>
                     
-                    <div class="col-md-6">
-                        <label class="form-label fw-semibold">{{ form.forma_movimento.label.text }}</label>
-                        {{ form.forma_movimento(id="forma_movimento", class="form-select") }}
-                    </div>
                 </div>
 
                 <div class="row mb-4">
@@ -68,13 +64,18 @@
                 <div class="row mb-4">
                     <div class="col-12">
                         <h5 class="text-primary border-bottom pb-2 mb-3">
-                            <i class="bi bi-cloud-upload me-2"></i>Envio Digital
+                            <i class="bi bi-cloud-upload me-2"></i>Tipo de Envio
                         </h5>
                     </div>
                 </div>
-                
+
                 <div class="row g-4 mb-4">
-                    <div class="col-md-6" id="envio_digital_container">
+                    <div class="col-md-4">
+                        <label class="form-label fw-semibold">{{ form.forma_movimento.label.text }}</label>
+                        {{ form.forma_movimento(id="forma_movimento", class="form-select") }}
+                    </div>
+
+                    <div class="col-md-4" id="envio_digital_container">
                         <label class="form-label fw-semibold">{{ form.envio_digital.label.text }}</label>
                         <div class="border rounded p-3 bg-light">
                             <div class="row">
@@ -89,8 +90,8 @@
                             </div>
                         </div>
                     </div>
-                    
-                    <div class="col-md-6" id="envio_fisico_container">
+
+                    <div class="col-md-4" id="envio_fisico_container">
                         <label class="form-label fw-semibold">{{ form.envio_fisico.label.text }}</label>
                         <div class="border rounded p-3 bg-light">
                             <div class="row">


### PR DESCRIPTION
## Summary
- Move envio digital/físico options beside shipping type selection
- Show all envio options in a unified block for fiscal and contabil forms

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_689cd15f6f20833088b6de117abe7b5f

## Summary by Sourcery

Group shipping type selection and envio options into a unified block with a consistent header and three-column layout in the fiscal and contabil registration forms.

Enhancements:
- Move shipping type selector into the same section as digital and physical shipping options in both fiscal and contabil forms
- Rename the shipping section header from 'Envio Digital' to 'Tipo de Envio'
- Adjust layout to display shipping type, digital shipping, and physical shipping as a unified three-column block with equal widths