### PR TITLE
Group movement type with shipping options

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -102,7 +102,7 @@ class DepartamentoFiscalForm(DepartamentoForm):
         ('nfce_xml_sieg', 'NFCe por XML - Sieg'), ('nfce_xml_cliente', 'NFCe por XML - Copiado do cliente'),
         ('nenhum', 'Não importa nada')], validators=[Optional()])
     links_prefeitura_json = HiddenField('Links Prefeitura', validators=[Optional()])
-    forma_movimento = SelectField('Forma de Recebimento do Movimento', choices=[
+    forma_movimento = SelectField('Envio de Documento', choices=[
         ('', 'Selecione'), ('Digital', 'Digital'), ('Fisico', 'Físico'), ('Digital e Físico', 'Digital e Físico')
     ], validators=[Optional()])
     envio_digital = SelectMultipleField('Envio Digital', choices=[
@@ -121,7 +121,7 @@ class DepartamentoContabilForm(DepartamentoForm):
     metodo_importacao = SelectField('Forma de Importação', choices=[
         ('', 'Selecione'), ('importado', 'Importado'), ('digitado', 'Digitado')
     ], validators=[Optional()])
-    forma_movimento = SelectField('Forma de Recebimento do Movimento', choices=[
+    forma_movimento = SelectField('Envio de Documento', choices=[
         ('', 'Selecione'), ('Digital', 'Digital'), ('Fisico', 'Físico'), ('Digital e Físico', 'Digital e Físico')
     ], validators=[Optional()])
     envio_digital = SelectMultipleField('Envio Digital', choices=[

--- a/app/static/javascript/forma_movimento.js
+++ b/app/static/javascript/forma_movimento.js
@@ -5,22 +5,34 @@ function setupFormaMovimento(selectId, digitalId, fisicoId) {
     if (!select || !digital || !fisico) {
         return;
     }
+    function clearContainer(container) {
+        const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+        checkboxes.forEach(cb => cb.checked = false);
+        const textInputs = container.querySelectorAll('input[type="text"]');
+        textInputs.forEach(input => input.value = '');
+    }
+
     function update() {
         const value = select.value;
         if (value === 'Digital') {
             digital.style.display = '';
             fisico.style.display = 'none';
+            clearContainer(fisico);
         } else if (value === 'Fisico') {
             digital.style.display = 'none';
             fisico.style.display = '';
+            clearContainer(digital);
         } else if (value === 'Digital e Físico') {
             digital.style.display = '';
             fisico.style.display = '';
         } else {
             digital.style.display = 'none';
             fisico.style.display = 'none';
+            clearContainer(digital);
+            clearContainer(fisico);
         }
     }
+
     select.addEventListener('change', update);
     update();
 }

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -28,20 +28,23 @@
                         <label class="form-label fw-semibold">{{ form.metodo_importacao.label.text }}</label>
                         {{ form.metodo_importacao(class="form-select") }}
                     </div>
+                </div>
+
+                <div class="row mb-4">
+                    <div class="col-12">
+                        <h5 class="text-primary border-bottom pb-2 mb-3">
+                            <i class="bi bi-cloud-upload me-2"></i>Envio de Documento
+                        </h5>
+                    </div>
+                </div>
+
+                <div class="row g-4 mb-4">
                     <div class="col-md-6">
                         <label class="form-label fw-semibold">{{ form.forma_movimento.label.text }}</label>
                         {{ form.forma_movimento(id="forma_movimento", class="form-select") }}
                     </div>
                 </div>
 
-                <div class="row mb-4">
-                    <div class="col-12">
-                        <h5 class="text-primary border-bottom pb-2 mb-3">
-                            <i class="bi bi-cloud-upload me-2"></i>Envio Digital
-                        </h5>
-                    </div>
-                </div>
-                
                 <div class="row g-4 mb-4">
                     <div class="col-md-6" id="envio_digital_container">
                         <label class="form-label fw-semibold">{{ form.envio_digital.label.text }}</label>
@@ -58,7 +61,7 @@
                             </div>
                         </div>
                     </div>
-                    
+
                     <div class="col-md-6" id="envio_fisico_container">
                         <label class="form-label fw-semibold">{{ form.envio_fisico.label.text }}</label>
                         <div class="border rounded p-3 bg-light">

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -40,11 +40,6 @@
                             </div>
                         </div>
                     </div>
-                    
-                    <div class="col-md-6">
-                        <label class="form-label fw-semibold">{{ form.forma_movimento.label.text }}</label>
-                        {{ form.forma_movimento(id="forma_movimento", class="form-select") }}
-                    </div>
                 </div>
 
                 <div class="row mb-4">
@@ -68,11 +63,18 @@
                 <div class="row mb-4">
                     <div class="col-12">
                         <h5 class="text-primary border-bottom pb-2 mb-3">
-                            <i class="bi bi-cloud-upload me-2"></i>Envio Digital
+                            <i class="bi bi-cloud-upload me-2"></i>Envio de Documento
                         </h5>
                     </div>
                 </div>
-                
+
+                <div class="row g-4 mb-4">
+                    <div class="col-md-6">
+                        <label class="form-label fw-semibold">{{ form.forma_movimento.label.text }}</label>
+                        {{ form.forma_movimento(id="forma_movimento", class="form-select") }}
+                    </div>
+                </div>
+
                 <div class="row g-4 mb-4">
                     <div class="col-md-6" id="envio_digital_container">
                         <label class="form-label fw-semibold">{{ form.envio_digital.label.text }}</label>
@@ -89,7 +91,7 @@
                             </div>
                         </div>
                     </div>
-                    
+
                     <div class="col-md-6" id="envio_fisico_container">
                         <label class="form-label fw-semibold">{{ form.envio_fisico.label.text }}</label>
                         <div class="border rounded p-3 bg-light">

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -56,10 +56,6 @@
                             {% for value, label in fiscal_form.formas_importacao.choices %}<div class="col-md-6 mb-2"><div class="form-check"><input class="form-check-input" type="checkbox" name="{{ fiscal_form.formas_importacao.name }}" value="{{ value }}" id="fi-{{ loop.index }}" {% if value in (fiscal_form.formas_importacao.data or []) %}checked{% endif %}><label class="form-check-label" for="fi-{{ loop.index }}">{{ label }}</label></div></div>{% endfor %}
                         </div></div>
                     </div>
-                    <div class="col-md-6">
-                        <label class="form-label fw-semibold">{{ fiscal_form.forma_movimento.label.text }}</label>
-                        {{ fiscal_form.forma_movimento(id="fiscal_forma_movimento", class="form-select") }}
-                    </div>
                 </div>
 
                 <h5 class="text-dept-blue border-bottom pb-2 mb-3"><i class="bi bi-building me-2"></i>Acesso à Prefeitura</h5>
@@ -73,10 +69,13 @@
                     </div>
                 </div>
 
-                <h5 class="text-dept-blue border-bottom pb-2 mb-3"><i class="bi bi-cloud-upload me-2"></i>Envio Digital e Contato</h5>
+                <h5 class="text-dept-blue border-bottom pb-2 mb-3"><i class="bi bi-cloud-upload me-2"></i>Envio de Documento e Contato</h5>
                 <div class="row g-4 mb-4">
                     <div class="col-md-6">
-                        <div id="fiscal_envio_digital">
+                        <label class="form-label fw-semibold">{{ fiscal_form.forma_movimento.label.text }}</label>
+                        {{ fiscal_form.forma_movimento(id="fiscal_forma_movimento", class="form-select") }}
+
+                        <div id="fiscal_envio_digital" class="mt-3">
                             <label class="form-label fw-semibold">{{ fiscal_form.envio_digital.label.text }}</label>
                             <div class="border rounded p-3 bg-light"><div class="row">
                                 {% for value, label in fiscal_form.envio_digital.choices %}
@@ -149,7 +148,7 @@
                 {{ contabil_form.hidden_tag() }}
                 <input type="hidden" name="form_type" value="contabil">
                 
-                <h5 class="text-dept-orange border-bottom pb-2 mb-3"><i class="bi bi-gear me-2"></i>Forma de Envio</h5>
+                <h5 class="text-dept-orange border-bottom pb-2 mb-3"><i class="bi bi-gear me-2"></i>Envio de Documento</h5>
                 <div class="row g-4 mb-4">
                     <div class="col-md-6"><label class="form-label fw-semibold">{{ contabil_form.metodo_importacao.label.text }}</label>{{ contabil_form.metodo_importacao(class="form-select") }}</div>
                     <div class="col-md-6"><label class="form-label fw-semibold">{{ contabil_form.forma_movimento.label.text }}</label>{{ contabil_form.forma_movimento(id="contabil_forma_movimento", class="form-select") }}</div>

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -159,12 +159,35 @@
             </div>
             <div class="card-body p-4">
                 <div class="row g-4">
-                    <div class="col-lg-6 col-md-12">
+                    <div class="col-12">
                         <div class="info-group">
-                            <h6 class="text-dept-blue mb-3 border-bottom pb-2"><i class="bi bi-info-circle me-2"></i>Informações Básicas</h6>
+                            <h6 class="text-dept-blue mb-3 border-bottom pb-2"><i class="bi bi-cloud-upload me-2"></i>Envio de Documento</h6>
                             <div class="info-item">
-                                <label class="info-label">Forma de Movimento</label>
+                                <label class="info-label">Envio de Documento</label>
                                 <div class="info-value">{% if fiscal.forma_movimento %}<span class="badge bg-dept-blue-subtle fs-6"><i class="bi bi-arrow-left-right me-1 text-dept-blue"></i>{{ fiscal.forma_movimento }}</span>{% else %}<span class="text-muted">Não informada</span>{% endif %}</div>
+                            </div>
+                            <div class="info-item">
+                                <label class="info-label">Envio Digital</label>
+                                <div class="info-value">
+                                    {% set placeholder_env_digital %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-cloud-slash fs-3 mb-2"></i><p class="mb-0 small">Não configurado</p></div>{% endset %}
+                                    {{ render_badge_list(fiscal.envio_digital, 'bg-dept-blue-subtle', 'bi-cloud-check', placeholder_env_digital) }}
+                                </div>
+                            </div>
+                            <div class="info-item">
+                                <label class="info-label">Envio Físico</label>
+                                <div class="info-value">
+                                    {% set placeholder_env_fisico %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-inbox fs-3 mb-2"></i><p class="mb-0 small">Não configurado</p></div>{% endset %}
+                                    {% set fisico_list = fiscal.envio_fisico %}
+                                    {% if fisico_list is string %}
+                                        {% set fisico_list = [fisico_list] %}
+                                    {% elif not fisico_list %}
+                                        {% set fisico_list = [] %}
+                                    {% endif %}
+                                    {% if fiscal.envio_fisico_outro %}
+                                        {% set fisico_list = fisico_list + [fiscal.envio_fisico_outro] %}
+                                    {% endif %}
+                                    {{ render_badge_list(fisico_list, 'bg-dept-blue-subtle', 'bi-inbox', placeholder_env_fisico) }}
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -234,37 +257,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="row g-4 mt-2">
-                    <div class="col-md-6">
-                         <div class="info-group">
-                            <h6 class="text-dept-blue mb-3 border-bottom pb-2"><i class="bi bi-cloud-upload me-2"></i>Envio Digital</h6>
-                            <div class="info-value">
-                                {% set placeholder_env_digital %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-cloud-slash fs-3 mb-2"></i><p class="mb-0 small">Não configurado</p></div>{% endset %}
-                                {{ render_badge_list(fiscal.envio_digital, 'bg-dept-blue-subtle', 'bi-cloud-check', placeholder_env_digital) }}
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-md-6">
-                         <div class="info-group">
-                            <h6 class="text-dept-blue mb-3 border-bottom pb-2"><i class="bi bi-inbox me-2"></i>Envio Físico</h6>
-                             <div class="info-value">
-                                {% set placeholder_env_fisico %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-inbox fs-3 mb-2"></i><p class="mb-0 small">Não configurado</p></div>{% endset %}
-                                {% set fisico_list = fiscal.envio_fisico %}
-                                {% if fisico_list is string %}
-                                    {% set fisico_list = [fisico_list] %}
-                                {% elif not fisico_list %}
-                                    {% set fisico_list = [] %}
-                                {% endif %}
-                                {% if fiscal.envio_fisico_outro %}
-                                    {% set fisico_list = fisico_list + [fiscal.envio_fisico_outro] %}
-                                {% endif %}
-                                {{ render_badge_list(fisico_list, 'bg-dept-blue-subtle', 'bi-inbox', placeholder_env_fisico) }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                 {% if fiscal.particularidades_texto and fiscal.particularidades_texto.strip() %}
+                {% if fiscal.particularidades_texto and fiscal.particularidades_texto.strip() %}
                 <div class="row mt-4">
                     <div class="col-12">
                         <div class="info-group">
@@ -302,39 +295,39 @@
                                 <label class="info-label">Método de Importação</label>
                                 <div class="info-value">{% if contabil.metodo_importacao %}<span class="badge bg-dept-orange-subtle fs-6"><i class="bi bi-download me-1 text-dept-orange"></i>{{ contabil.metodo_importacao }}</span>{% else %}<span class="text-muted">Não informado</span>{% endif %}</div>
                             </div>
-                            <div class="info-item">
-                                <label class="info-label">Forma de Movimento</label>
-                                <div class="info-value">{% if contabil.forma_movimento %}<span class="badge bg-dept-orange-subtle fs-6"><i class="bi bi-arrow-left-right me-1 text-dept-orange"></i>{{ contabil.forma_movimento }}</span>{% else %}<span class="text-muted">Não informada</span>{% endif %}</div>
-                            </div>
                         </div>
                     </div>
                 </div>
-
-                <div class="row g-4 mt-2">
-                    <div class="col-md-6">
+                <div class="row g-4">
+                    <div class="col-12">
                         <div class="info-group">
-                            <h6 class="text-dept-orange mb-3 border-bottom pb-2"><i class="bi bi-cloud-upload me-2"></i>Envio Digital</h6>
-                            <div class="info-value">
-                                {% set placeholder_cont_digital %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-cloud-slash fs-3 mb-2"></i><p class="mb-0 small">Não configurado</p></div>{% endset %}
-                                {{ render_badge_list(contabil.envio_digital, 'bg-dept-orange-subtle', 'bi-cloud-check', placeholder_cont_digital) }}
+                            <h6 class="text-dept-orange mb-3 border-bottom pb-2"><i class="bi bi-cloud-upload me-2"></i>Envio de Documento</h6>
+                            <div class="info-item">
+                                <label class="info-label">Envio de Documento</label>
+                                <div class="info-value">{% if contabil.forma_movimento %}<span class="badge bg-dept-orange-subtle fs-6"><i class="bi bi-arrow-left-right me-1 text-dept-orange"></i>{{ contabil.forma_movimento }}</span>{% else %}<span class="text-muted">Não informada</span>{% endif %}</div>
                             </div>
-                        </div>
-                    </div>
-                    <div class="col-md-6">
-                        <div class="info-group">
-                            <h6 class="text-dept-orange mb-3 border-bottom pb-2"><i class="bi bi-inbox me-2"></i>Envio Físico</h6>
-                            <div class="info-value">
-                                {% set placeholder_cont_fisico %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-inbox fs-3 mb-2"></i><p class="mb-0 small">Não configurado</p></div>{% endset %}
-                                {% set cont_fisico = contabil.envio_fisico %}
-                                {% if cont_fisico is string %}
-                                    {% set cont_fisico = [cont_fisico] %}
-                                {% elif not cont_fisico %}
-                                    {% set cont_fisico = [] %}
-                                {% endif %}
-                                {% if contabil.envio_fisico_outro %}
-                                    {% set cont_fisico = cont_fisico + [contabil.envio_fisico_outro] %}
-                                {% endif %}
-                                {{ render_badge_list(cont_fisico, 'bg-dept-orange-subtle', 'bi-inbox', placeholder_cont_fisico) }}
+                            <div class="info-item">
+                                <label class="info-label">Envio Digital</label>
+                                <div class="info-value">
+                                    {% set placeholder_cont_digital %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-cloud-slash fs-3 mb-2"></i><p class="mb-0 small">Não configurado</p></div>{% endset %}
+                                    {{ render_badge_list(contabil.envio_digital, 'bg-dept-orange-subtle', 'bi-cloud-check', placeholder_cont_digital) }}
+                                </div>
+                            </div>
+                            <div class="info-item">
+                                <label class="info-label">Envio Físico</label>
+                                <div class="info-value">
+                                    {% set placeholder_cont_fisico %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-inbox fs-3 mb-2"></i><p class="mb-0 small">Não configurado</p></div>{% endset %}
+                                    {% set cont_fisico = contabil.envio_fisico %}
+                                    {% if cont_fisico is string %}
+                                        {% set cont_fisico = [cont_fisico] %}
+                                    {% elif not cont_fisico %}
+                                        {% set cont_fisico = [] %}
+                                    {% endif %}
+                                    {% if contabil.envio_fisico_outro %}
+                                        {% set cont_fisico = cont_fisico + [contabil.envio_fisico_outro] %}
+                                    {% endif %}
+                                    {{ render_badge_list(cont_fisico, 'bg-dept-orange-subtle', 'bi-inbox', placeholder_cont_fisico) }}
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Rename movement type selector to "Envio de Documento" and keep it with shipment options on department forms
- Show movement type alongside digital and physical shipment details on company view
- Clear previous shipment selections automatically when movement type changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cebace9e08330a7c46503305cee49