### PR TITLE
Reduce search bar width on company listing page

### DIFF
--- a/app/templates/empresas/listar.html
+++ b/app/templates/empresas/listar.html
@@ -37,7 +37,7 @@
 
     <!-- Barra de Pesquisa -->
     <form method="GET" class="d-flex mb-3">
-        <input type="text" name="q" class="form-control me-2" placeholder="Buscar empresa" value="{{ search or '' }}">
+        <input type="text" name="q" class="form-control me-2" style="max-width: 300px;" placeholder="Buscar empresa" value="{{ search or '' }}">
         <button class="btn btn-outline-secondary" type="submit">
             <i class="bi bi-search"></i>
         </button>


### PR DESCRIPTION
## Summary
- limit width of company search input on listing page so it displays smaller

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689dbc8909d8833098aab329e5305783

## Summary by Sourcery

Enhancements:
- Limit the width of the company search input to a maximum of 300px on the listing page