### PR TITLE
Hide ID column in user list

### DIFF
--- a/app/templates/list_users.html
+++ b/app/templates/list_users.html
@@ -44,7 +44,6 @@
                 <table class="table table-bordered table-hover mb-0">
                     <thead class="table-primary">
                         <tr>
-                            <th style="width: 80px;">ID</th>
                             <th>Nome</th>
                             <th style="width: 300px;">Email</th>
                             <th style="width: 150px;">Usuário</th>
@@ -55,11 +54,6 @@
                     <tbody>
                         {% for user in users %}
                         <tr>
-                            <td>
-                                <span class="badge bg-primary-subtle text-primary fw-semibold">
-                                    {{ user.id }}
-                                </span>
-                            </td>
                             <td>
                                 <div class="d-flex align-items-center">
                                     <i class="bi bi-person-circle me-2 text-muted"></i>
@@ -82,8 +76,8 @@
                                 {% endif %}
                             </td>
                             <td class="text-center">
-                                <a href="{{ url_for('edit_user', user_id=user.id) }}" 
-                                   class="btn btn-sm btn-outline-primary" 
+                                <a href="{{ url_for('edit_user', user_id=user.id) }}"
+                                   class="btn btn-sm btn-outline-primary"
                                    title="Editar usuário">
                                     <i class="bi bi-pencil"></i>
                                 </a>
@@ -91,7 +85,7 @@
                         </tr>
                         {% else %}
                         <tr>
-                            <td colspan="6" class="text-center py-5">
+                            <td colspan="5" class="text-center py-5">
                                 <div class="text-muted">
                                     <i class="bi bi-person-slash fs-1 d-block mb-3"></i>
                                     <h5>Nenhum usuário cadastrado</h5>


### PR DESCRIPTION
## Summary
- remove ID column from user list template
- adjust empty state colspan to match new table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689dbe0f6df88330a92358be739d7e16

## Summary by Sourcery

Remove the ID column from the user list table and update the table layout accordingly

Enhancements:
- Remove the ID column from the user list template
- Adjust the empty-state row colspan to match the updated column count