### PR TITLE
Hide ID column in user list

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -604,6 +604,8 @@ def test_connection():
 @admin_required
 def list_users():
     form = RegistrationForm()
+    show_inactive = request.args.get('show_inactive') in ('1', 'on')
+
     if form.validate_on_submit():
         existing_user = User.query.filter(
             (User.username == form.username.data) | (User.email == form.email.data)
@@ -623,8 +625,11 @@ def list_users():
             flash('Novo usuário cadastrado com sucesso!', 'success')
         return redirect(url_for('list_users'))
 
-    users = User.query.all()
-    return render_template('list_users.html', users=users, form=form)
+    users_query = User.query
+    if not show_inactive:
+        users_query = users_query.filter_by(ativo=True)
+    users = users_query.all()
+    return render_template('list_users.html', users=users, form=form, show_inactive=show_inactive)
 
 @app.route('/novo_usuario', methods=['GET', 'POST'])
 @login_required

--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -628,7 +628,7 @@ def list_users():
     users_query = User.query
     if not show_inactive:
         users_query = users_query.filter_by(ativo=True)
-    users = users_query.all()
+    users = users_query.order_by(User.ativo.desc(), User.name).all()
     return render_template('list_users.html', users=users, form=form, show_inactive=show_inactive)
 
 @app.route('/novo_usuario', methods=['GET', 'POST'])

--- a/app/templates/list_users.html
+++ b/app/templates/list_users.html
@@ -15,7 +15,11 @@
                     </h1>
                     <p class="text-muted mb-0">Gerencie os usuários do sistema</p>
                 </div>
-                <div class="text-end">
+                <div class="d-flex align-items-center justify-content-end gap-3">
+                    <form method="get" class="form-check mb-0">
+                        <input class="form-check-input" type="checkbox" id="showInactive" name="show_inactive" {% if show_inactive %}checked{% endif %} onchange="this.form.submit()">
+                        <label class="form-check-label" for="showInactive">Mostrar inativos</label>
+                    </form>
                     <a href="{{ url_for('novo_usuario') }}" class="btn btn-primary">
                         <i class="bi bi-person-plus me-1"></i>Novo Usuário
                     </a>
@@ -44,7 +48,6 @@
                 <table class="table table-bordered table-hover mb-0">
                     <thead class="table-primary">
                         <tr>
-                            <th style="width: 80px;">ID</th>
                             <th>Nome</th>
                             <th style="width: 300px;">Email</th>
                             <th style="width: 150px;">Usuário</th>
@@ -54,16 +57,14 @@
                     </thead>
                     <tbody>
                         {% for user in users %}
-                        <tr>
-                            <td>
-                                <span class="badge bg-primary-subtle text-primary fw-semibold">
-                                    {{ user.id }}
-                                </span>
-                            </td>
+                        <tr {% if not user.ativo %}class="table-secondary"{% endif %}>
                             <td>
                                 <div class="d-flex align-items-center">
                                     <i class="bi bi-person-circle me-2 text-muted"></i>
                                     <div class="fw-semibold">{{ user.name }}</div>
+                                    {% if not user.ativo %}
+                                        <span class="badge bg-secondary ms-2">Inativo</span>
+                                    {% endif %}
                                 </div>
                             </td>
                             <td>
@@ -82,8 +83,8 @@
                                 {% endif %}
                             </td>
                             <td class="text-center">
-                                <a href="{{ url_for('edit_user', user_id=user.id) }}" 
-                                   class="btn btn-sm btn-outline-primary" 
+                                <a href="{{ url_for('edit_user', user_id=user.id) }}"
+                                   class="btn btn-sm btn-outline-primary"
                                    title="Editar usuário">
                                     <i class="bi bi-pencil"></i>
                                 </a>
@@ -91,7 +92,7 @@
                         </tr>
                         {% else %}
                         <tr>
-                            <td colspan="6" class="text-center py-5">
+                            <td colspan="5" class="text-center py-5">
                                 <div class="text-muted">
                                     <i class="bi bi-person-slash fs-1 d-block mb-3"></i>
                                     <h5>Nenhum usuário cadastrado</h5>


### PR DESCRIPTION
## Summary
- remove ID column from user list template
- adjust empty state colspan to match new table
- filter list to show only active users by default and add checkbox to display inactive users

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689dbe0f6df88330a92358be739d7e16

## Summary by Sourcery

Remove the ID column from the user list, filter to active users by default, and introduce a toggle to display inactive users with appropriate visual cues.

New Features:
- Add a checkbox to toggle the display of inactive users in the user list
- Filter the user listing to show only active users by default

Enhancements:
- Remove the ID column and adjust the empty-state colspan to fit the new table structure
- Highlight inactive users with a secondary row style and an “Inativo” badge