### PR TITLE
Display update timestamps in Brasília timezone

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,8 +5,9 @@ from flask_migrate import Migrate
 from flask_wtf.csrf import CSRFProtect
 from flask_login import LoginManager
 from dotenv import load_dotenv
-from datetime import datetime
+from datetime import datetime, timezone
 from markupsafe import Markup
+from zoneinfo import ZoneInfo
 
 load_dotenv()
 
@@ -34,6 +35,16 @@ def load_user(user_id):
 @app.context_processor
 def inject_now():
     return {'now': datetime.now}
+
+BR_TZ = ZoneInfo("America/Sao_Paulo")
+
+@app.template_filter('datetime_br')
+def datetime_br(value):
+    if not value:
+        return ''
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(BR_TZ).strftime('%d/%m/%Y às %H:%M')
 
 @app.template_global()
 def render_badge_list(items, classes, icon, placeholder):

--- a/app/templates/departamentos/cadastrar.html
+++ b/app/templates/departamentos/cadastrar.html
@@ -75,7 +75,7 @@
                     <div class="alert alert-info d-flex align-items-center" role="alert">
                         <i class="bi bi-clock me-2"></i>
                         <div>
-                            <strong>Última atualização:</strong> {{ departamento.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                            <strong>Última atualização:</strong> {{ departamento.updated_at|datetime_br }}
                         </div>
                     </div>
                 </div>

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -150,7 +150,7 @@
                     <div class="alert alert-info d-flex align-items-center" role="alert">
                         <i class="bi bi-clock me-2"></i>
                         <div>
-                            <strong>Última atualização:</strong> {{ departamento.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                            <strong>Última atualização:</strong> {{ departamento.updated_at|datetime_br }}
                         </div>
                     </div>
                 </div>

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -180,7 +180,7 @@
                     <div class="alert alert-info d-flex align-items-center" role="alert">
                         <i class="bi bi-clock me-2"></i>
                         <div>
-                            <strong>Última atualização:</strong> {{ departamento.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                            <strong>Última atualização:</strong> {{ departamento.updated_at|datetime_br }}
                         </div>
                     </div>
                 </div>

--- a/app/templates/departamentos/cadastrar_pessoal.html
+++ b/app/templates/departamentos/cadastrar_pessoal.html
@@ -111,7 +111,7 @@
                     <div class="alert alert-info d-flex align-items-center" role="alert">
                         <i class="bi bi-clock me-2"></i>
                         <div>
-                            <strong>Última atualização:</strong> {{ departamento.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                            <strong>Última atualização:</strong> {{ departamento.updated_at|datetime_br }}
                         </div>
                     </div>
                 </div>

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -137,7 +137,7 @@
                     <button type="submit" class="btn btn-dept-blue px-5"><i class="bi bi-check-lg me-2"></i>Salvar Departamento Fiscal</button>
                 </div>
             </form>
-            {% if fiscal and fiscal.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ fiscal.updated_at.strftime('%d/%m/%Y às %H:%M') }}</div></div></div>{% endif %}
+            {% if fiscal and fiscal.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ fiscal.updated_at|datetime_br }}</div></div></div>{% endif %}
         </div>
     </div>
 
@@ -225,7 +225,7 @@
                     <button type="submit" class="btn btn-dept-orange px-5"><i class="bi bi-check-lg me-2"></i>Salvar Departamento Contábil</button>
                 </div>
             </form>
-            {% if contabil and contabil.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ contabil.updated_at.strftime('%d/%m/%Y às %H:%M') }}</div></div></div>{% endif %}
+            {% if contabil and contabil.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ contabil.updated_at|datetime_br }}</div></div></div>{% endif %}
         </div>
     </div>
 
@@ -299,7 +299,7 @@
                 <div class="alert alert-secondary d-flex align-items-center" role="alert">
                     <i class="bi bi-clock me-2"></i>
                     <div>
-                        <strong>Última atualização:</strong> {{ pessoal.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                        <strong>Última atualização:</strong> {{ pessoal.updated_at|datetime_br }}
                     </div>
                 </div>
             </div>
@@ -318,7 +318,7 @@
                     <button type="submit" class="btn btn-dept-orange px-5"><i class="bi bi-check-lg me-2"></i>Salvar Departamento Administrativo</button>
                 </div>
             </form>
-            {% if administrativo and administrativo.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ administrativo.updated_at.strftime('%d/%m/%Y às %H:%M') }}</div></div></div>{% endif %}
+            {% if administrativo and administrativo.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ administrativo.updated_at|datetime_br }}</div></div></div>{% endif %}
         </div>
     </div>
 

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -154,7 +154,7 @@
             <div class="card-header bg-dept-blue text-white py-3">
                 <div class="d-flex justify-content-between align-items-center">
                     <h3 class="mb-0 fw-semibold"><i class="bi bi-receipt me-2"></i>Departamento Fiscal</h3>
-                    {% if fiscal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ fiscal.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
+                    {% if fiscal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ fiscal.updated_at|datetime_br }}</small>{% endif %}
                 </div>
             </div>
             <div class="card-body p-4">
@@ -283,7 +283,7 @@
             <div class="card-header bg-dept-orange text-white py-3">
                 <div class="d-flex justify-content-between align-items-center">
                     <h3 class="mb-0 fw-semibold"><i class="bi bi-calculator me-2"></i>Departamento Contábil</h3>
-                    {% if contabil.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ contabil.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
+                    {% if contabil.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ contabil.updated_at|datetime_br }}</small>{% endif %}
                 </div>
             </div>
             <div class="card-body p-4">
@@ -370,7 +370,7 @@
                 <div class="card-header bg-dept-blue text-white py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <h3 class="mb-0 fw-semibold"><i class="bi bi-people me-2"></i>Departamento Pessoal</h3>
-                        {% if pessoal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ pessoal.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
+                        {% if pessoal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ pessoal.updated_at|datetime_br }}</small>{% endif %}
                     </div>
                 </div>
                 <div class="card-body p-4">
@@ -449,7 +449,7 @@
             <div class="card-header bg-dept-orange text-white py-3">
                  <div class="d-flex justify-content-between align-items-center">
                     <h3 class="mb-0 fw-semibold"><i class="bi bi-gear me-2"></i>Departamento Administrativo</h3>
-                    {% if administrativo.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ administrativo.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
+                    {% if administrativo.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ administrativo.updated_at|datetime_br }}</small>{% endif %}
                 </div>
             </div>
             <div class="card-body p-4">


### PR DESCRIPTION
## Summary
- add `datetime_br` template filter using zoneinfo to render datetimes in America/Sao_Paulo (UTC-3)
- use new filter across department and company templates for update timestamps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689dc6004cfc83308b656ea7ee9b1e7f

## Summary by Sourcery

Introduce a Brasília timezone-aware datetime formatter as a Jinja filter and apply it across templates to standardize update timestamp display

New Features:
- Add datetime_br Jinja template filter for formatting datetimes in the America/Sao_Paulo timezone

Enhancements:
- Replace manual strftime calls in company and department templates with the datetime_br filter for update timestamps