### PR TITLE
Exibir hora UTC-3 no rodapé

### DIFF
--- a/app/static/javascript/hora.js
+++ b/app/static/javascript/hora.js
@@ -1,0 +1,17 @@
+function atualizarHoraUTC3() {
+  const options = {
+    timeZone: 'America/Sao_Paulo',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  };
+  const now = new Date().toLocaleTimeString('pt-BR', options);
+  const elementoHora = document.getElementById('current-time');
+  if (elementoHora) {
+    elementoHora.textContent = now;
+  }
+}
+
+setInterval(atualizarHoraUTC3, 1000);
+atualizarHoraUTC3();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -465,7 +465,7 @@
     <footer class="text-center">
         <div class="container">
             <div class="d-flex justify-content-between align-items-center">
-                <span>JP Contábil &copy; {{ now().year }}</span>
+                <span>JP Contábil &copy; {{ now().year }} - <span id="current-time"></span></span>
                 <span>Desenvolvido por TI JP Contábil</span>
             </div>
         </div>
@@ -477,6 +477,7 @@
 <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
 <script src="{{ url_for('static', filename='javascript/mensagens.js') }}"></script>
 <script src="{{ url_for('static', filename='javascript/paste_images.js') }}"></script>
+<script src="{{ url_for('static', filename='javascript/hora.js') }}"></script>
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- Mostrar horário atual (UTC-3) no rodapé do site
- Atualização automática a cada segundo via JavaScript

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689dcc47c8308330ac0cfc45703e4d48

## Summary by Sourcery

Display the current UTC-3 time in the site footer and refresh it every second via JavaScript

New Features:
- Add a live UTC-3 clock display to the site footer

Enhancements:
- Automatically update the footer clock every second using a new JavaScript module