### PR TITLE
Show update timestamps in Brasília time

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,8 +5,7 @@ from flask_migrate import Migrate
 from flask_wtf.csrf import CSRFProtect
 from flask_login import LoginManager
 from dotenv import load_dotenv
-from datetime import datetime, timezone
-from zoneinfo import ZoneInfo
+from datetime import datetime, timezone, timedelta
 from markupsafe import Markup
 
 load_dotenv()
@@ -23,7 +22,7 @@ migrate = Migrate(app, db)
 login_manager = LoginManager(app)
 login_manager.login_view = 'login'
 
-BRASILIA_TZ = ZoneInfo("America/Sao_Paulo")
+BRASILIA_TZ = timezone(timedelta(hours=-3))
 
 # Importa rotas e modelos depois da criação do db
 from app.models import tables

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -2,7 +2,7 @@ import json
 from sqlalchemy.types import TypeDecorator, String
 from app import db
 from enum import Enum
-from datetime import datetime, timezone
+from datetime import datetime
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
 
@@ -91,7 +91,7 @@ class Departamento(db.Model):
     ponto_eletronico = db.Column(db.String(200))
     pagamento_funcionario = db.Column(db.String(200))
     particularidades_texto = db.Column(db.Text)
-    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     empresa = db.relationship('Empresa', backref=db.backref('departamentos', lazy=True))
 
     def __repr__(self):

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -2,7 +2,7 @@ import json
 from sqlalchemy.types import TypeDecorator, String
 from app import db
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, timezone
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
 
@@ -91,7 +91,7 @@ class Departamento(db.Model):
     ponto_eletronico = db.Column(db.String(200))
     pagamento_funcionario = db.Column(db.String(200))
     particularidades_texto = db.Column(db.Text)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     empresa = db.relationship('Empresa', backref=db.backref('departamentos', lazy=True))
 
     def __repr__(self):

--- a/app/templates/departamentos/cadastrar.html
+++ b/app/templates/departamentos/cadastrar.html
@@ -75,7 +75,7 @@
                     <div class="alert alert-info d-flex align-items-center" role="alert">
                         <i class="bi bi-clock me-2"></i>
                         <div>
-                            <strong>Última atualização:</strong> {{ departamento.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                            <strong>Última atualização:</strong> {{ departamento.updated_at|format_brasilia }}
                         </div>
                     </div>
                 </div>

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -150,7 +150,7 @@
                     <div class="alert alert-info d-flex align-items-center" role="alert">
                         <i class="bi bi-clock me-2"></i>
                         <div>
-                            <strong>Última atualização:</strong> {{ departamento.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                            <strong>Última atualização:</strong> {{ departamento.updated_at|format_brasilia }}
                         </div>
                     </div>
                 </div>

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -180,7 +180,7 @@
                     <div class="alert alert-info d-flex align-items-center" role="alert">
                         <i class="bi bi-clock me-2"></i>
                         <div>
-                            <strong>Última atualização:</strong> {{ departamento.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                            <strong>Última atualização:</strong> {{ departamento.updated_at|format_brasilia }}
                         </div>
                     </div>
                 </div>

--- a/app/templates/departamentos/cadastrar_pessoal.html
+++ b/app/templates/departamentos/cadastrar_pessoal.html
@@ -111,7 +111,7 @@
                     <div class="alert alert-info d-flex align-items-center" role="alert">
                         <i class="bi bi-clock me-2"></i>
                         <div>
-                            <strong>Última atualização:</strong> {{ departamento.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                            <strong>Última atualização:</strong> {{ departamento.updated_at|format_brasilia }}
                         </div>
                     </div>
                 </div>

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -137,7 +137,7 @@
                     <button type="submit" class="btn btn-dept-blue px-5"><i class="bi bi-check-lg me-2"></i>Salvar Departamento Fiscal</button>
                 </div>
             </form>
-            {% if fiscal and fiscal.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ fiscal.updated_at.strftime('%d/%m/%Y às %H:%M') }}</div></div></div>{% endif %}
+            {% if fiscal and fiscal.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ fiscal.updated_at|format_brasilia }}</div></div></div>{% endif %}
         </div>
     </div>
 
@@ -225,7 +225,7 @@
                     <button type="submit" class="btn btn-dept-orange px-5"><i class="bi bi-check-lg me-2"></i>Salvar Departamento Contábil</button>
                 </div>
             </form>
-            {% if contabil and contabil.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ contabil.updated_at.strftime('%d/%m/%Y às %H:%M') }}</div></div></div>{% endif %}
+            {% if contabil and contabil.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ contabil.updated_at|format_brasilia }}</div></div></div>{% endif %}
         </div>
     </div>
 
@@ -299,7 +299,7 @@
                 <div class="alert alert-secondary d-flex align-items-center" role="alert">
                     <i class="bi bi-clock me-2"></i>
                     <div>
-                        <strong>Última atualização:</strong> {{ pessoal.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                        <strong>Última atualização:</strong> {{ pessoal.updated_at|format_brasilia }}
                     </div>
                 </div>
             </div>
@@ -318,7 +318,7 @@
                     <button type="submit" class="btn btn-dept-orange px-5"><i class="bi bi-check-lg me-2"></i>Salvar Departamento Administrativo</button>
                 </div>
             </form>
-            {% if administrativo and administrativo.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ administrativo.updated_at.strftime('%d/%m/%Y às %H:%M') }}</div></div></div>{% endif %}
+            {% if administrativo and administrativo.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ administrativo.updated_at|format_brasilia }}</div></div></div>{% endif %}
         </div>
     </div>
 

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -154,7 +154,7 @@
             <div class="card-header bg-dept-blue text-white py-3">
                 <div class="d-flex justify-content-between align-items-center">
                     <h3 class="mb-0 fw-semibold"><i class="bi bi-receipt me-2"></i>Departamento Fiscal</h3>
-                    {% if fiscal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ fiscal.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
+                    {% if fiscal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ fiscal.updated_at|format_brasilia }}</small>{% endif %}
                 </div>
             </div>
             <div class="card-body p-4">
@@ -283,7 +283,7 @@
             <div class="card-header bg-dept-orange text-white py-3">
                 <div class="d-flex justify-content-between align-items-center">
                     <h3 class="mb-0 fw-semibold"><i class="bi bi-calculator me-2"></i>Departamento Contábil</h3>
-                    {% if contabil.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ contabil.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
+                    {% if contabil.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ contabil.updated_at|format_brasilia }}</small>{% endif %}
                 </div>
             </div>
             <div class="card-body p-4">
@@ -370,7 +370,7 @@
                 <div class="card-header bg-dept-blue text-white py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <h3 class="mb-0 fw-semibold"><i class="bi bi-people me-2"></i>Departamento Pessoal</h3>
-                        {% if pessoal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ pessoal.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
+                        {% if pessoal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ pessoal.updated_at|format_brasilia }}</small>{% endif %}
                     </div>
                 </div>
                 <div class="card-body p-4">
@@ -449,7 +449,7 @@
             <div class="card-header bg-dept-orange text-white py-3">
                  <div class="d-flex justify-content-between align-items-center">
                     <h3 class="mb-0 fw-semibold"><i class="bi bi-gear me-2"></i>Departamento Administrativo</h3>
-                    {% if administrativo.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ administrativo.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
+                    {% if administrativo.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ administrativo.updated_at|format_brasilia }}</small>{% endif %}
                 </div>
             </div>
             <div class="card-body p-4">


### PR DESCRIPTION
## Summary
- add filter to format datetimes in America/Sao_Paulo timezone
- save Departamento update timestamps in UTC
- display update timestamps using Brazil timezone across templates

## Testing
- `pytest 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_b_689dd2cdafe883309753b59128aaafc9

## Summary by Sourcery

Ensure all update timestamps are stored in UTC and consistently displayed in Brasília time by introducing a template filter and adjusting model defaults and templates.

New Features:
- Add a Jinja template filter to format datetimes in Brasília time
- Inject a context processor to supply the current time in Brasília timezone

Enhancements:
- Store departamento.updated_at timestamps as timezone-aware UTC datetimes
- Update templates to use the new format_brasilia filter for all last-update displays