### PR TITLE
Add Google Chat option for digital submissions

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -106,7 +106,8 @@ class DepartamentoFiscalForm(DepartamentoForm):
         ('', 'Selecione'), ('Digital', 'Digital'), ('Fisico', 'Físico'), ('Digital e Físico', 'Digital e Físico')
     ], validators=[Optional()])
     envio_digital = SelectMultipleField('Envio Digital', choices=[
-        ('email', 'Email'), ('whatsapp', 'Whatsapp'), ('acessorias', 'Acessórias')
+        ('email', 'Email'), ('whatsapp', 'Whatsapp'), ('acessorias', 'Acessórias'),
+        ('google_chat', 'Google Chat')
     ], validators=[Optional()])
     envio_fisico = SelectMultipleField('Envio Físico', choices=[
         ('malote', 'Malote'), ('outro', 'Outro')
@@ -125,7 +126,8 @@ class DepartamentoContabilForm(DepartamentoForm):
         ('', 'Selecione'), ('Digital', 'Digital'), ('Fisico', 'Físico'), ('Digital e Físico', 'Digital e Físico')
     ], validators=[Optional()])
     envio_digital = SelectMultipleField('Envio Digital', choices=[
-        ('email', 'Email'), ('whatsapp', 'Whatsapp'), ('acessorias', 'Acessórias')
+        ('email', 'Email'), ('whatsapp', 'Whatsapp'), ('acessorias', 'Acessórias'),
+        ('google_chat', 'Google Chat')
     ], validators=[Optional()])
     envio_fisico = SelectMultipleField('Envio Físico', choices=[
         ('malote', 'Malote'), ('outro', 'Outro')

--- a/app/static/javascript/contatos.js
+++ b/app/static/javascript/contatos.js
@@ -41,6 +41,7 @@ function setupContatos(containerId, addBtnId, hiddenInputId) {
                 <option value="email" ${m.tipo === 'email' ? 'selected' : ''}>E-mail</option>
                 <option value="telefone" ${m.tipo === 'telefone' ? 'selected' : ''}>Telefone</option>
                 <option value="whatsapp" ${m.tipo === 'whatsapp' ? 'selected' : ''}>Whatsapp</option>
+                <option value="google_chat" ${m.tipo === 'google_chat' ? 'selected' : ''}>Google Chat</option>
                 <option value="acessorias" ${m.tipo === 'acessorias' ? 'selected' : ''}>Acessórias</option>
               </select>
             </div>


### PR DESCRIPTION
## Summary
- add Google Chat as a digital submission method for fiscal and accounting departments
- enable Google Chat as a contact option

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689de0095b448330b8f434ab051d0883

## Summary by Sourcery

Add Google Chat as a digital submission and contact option

New Features:
- Add Google Chat choice to envio_digital in fiscal department form
- Add Google Chat choice to envio_digital in accounting department form
- Add Google Chat option to contact method dropdown in contatos.js