### PR TITLE
Refine physical document handling to require malote movement choice

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -249,7 +249,9 @@ def processar_dados_fiscal(request):
     formas_importacao = json.loads(formas_importacao_json) if formas_importacao_json else []
     envio_digital = request.form.getlist('envio_digital')
     envio_fisico = request.form.getlist('envio_fisico')
-    envio_fisico_outro = request.form.get('envio_fisico_outro')
+    malote_movimento = request.form.get('malote_movimento')
+    if 'malote' not in envio_fisico:
+        malote_movimento = None
     contatos_json = request.form.get('contatos_json', 'null')
     contatos = json.loads(contatos_json) if contatos_json != 'null' else None
     if contatos is not None:
@@ -263,7 +265,7 @@ def processar_dados_fiscal(request):
         'forma_movimento': forma_movimento,
         'envio_digital': envio_digital,
         'envio_fisico': envio_fisico,
-        'envio_fisico_outro': envio_fisico_outro,
+        'malote_movimento': malote_movimento,
         'observacao_movimento': observacao_movimento,
         'contatos': contatos,
         'particularidades_texto': particularidades
@@ -278,10 +280,12 @@ def processar_dados_contabil(request):
     particularidades = request.form.get('particularidades')
     envio_digital = request.form.getlist('envio_digital')
     envio_fisico = request.form.getlist('envio_fisico')
-    envio_fisico_outro = request.form.get('envio_fisico_outro')
+    malote_movimento = request.form.get('malote_movimento')
+    if 'malote' not in envio_fisico:
+        malote_movimento = None
     controle_relatorios_json = request.form.get('controle_relatorios_json', '[]')
     controle_relatorios = json.loads(controle_relatorios_json) if controle_relatorios_json else []
-    
+
     return {
         'responsavel': responsavel,
         'descricao': descricao,
@@ -289,7 +293,7 @@ def processar_dados_contabil(request):
         'forma_movimento': forma_movimento,
         'envio_digital': envio_digital,
         'envio_fisico': envio_fisico,
-        'envio_fisico_outro': envio_fisico_outro,
+        'malote_movimento': malote_movimento,
         'controle_relatorios': controle_relatorios,
         'particularidades_texto': particularidades
     }
@@ -471,7 +475,6 @@ def gerenciar_departamentos(empresa_id):
                 contabil_form.envio_fisico.data = json.loads(contabil.envio_fisico) if contabil.envio_fisico else []
             except Exception:
                 contabil_form.envio_fisico.data = []
-            contabil_form.envio_fisico_outro.data = contabil.envio_fisico_outro
             
             try:
                 contabil_form.controle_relatorios.data = json.loads(contabil.controle_relatorios) if contabil.controle_relatorios else []
@@ -489,6 +492,8 @@ def gerenciar_departamentos(empresa_id):
                 db.session.add(fiscal)
 
             fiscal_form.populate_obj(fiscal)
+            if 'malote' not in (fiscal_form.envio_fisico.data or []):
+                fiscal.malote_movimento = None
             try:
                 fiscal.contatos = json.loads(fiscal_form.contatos_json.data or '[]')
             except Exception:
@@ -509,7 +514,8 @@ def gerenciar_departamentos(empresa_id):
 
             contabil.envio_digital = json.dumps(contabil_form.envio_digital.data or [])
             contabil.envio_fisico = json.dumps(contabil_form.envio_fisico.data or [])
-            contabil.envio_fisico_outro = contabil_form.envio_fisico_outro.data
+            if 'malote' not in (contabil_form.envio_fisico.data or []):
+                contabil.malote_movimento = None
             contabil.controle_relatorios = json.dumps(contabil_form.controle_relatorios.data or [])
             
             flash('Departamento Contábil salvo com sucesso!', 'success')

--- a/app/forms.py
+++ b/app/forms.py
@@ -110,9 +110,20 @@ class DepartamentoFiscalForm(DepartamentoForm):
         ('google_chat', 'Google Chat')
     ], validators=[Optional()])
     envio_fisico = SelectMultipleField('Envio Físico', choices=[
-        ('malote', 'Malote'), ('outro', 'Outro')
+        ('malote', 'Malote')
     ], validators=[Optional()])
-    envio_fisico_outro = StringField('Outro', validators=[Optional()])
+    malote_movimento = SelectField(
+        'Movimento Físico',
+        choices=[
+            ('', 'Selecione'),
+            ('eles_trazem', 'Eles trazem'),
+            ('nos_buscamos', 'Nós buscamos')
+        ],
+        validators=[Optional()]
+    )
+    def validate_malote_movimento(form, field):
+        if 'malote' in (form.envio_fisico.data or []) and not field.data:
+            raise ValidationError('Selecione uma opção para o malote')
     observacao_movimento = TextAreaField('Observação', validators=[Optional()])
     contatos_json = HiddenField('Contatos', validators=[Optional()])
     particularidades_texto = TextAreaField('Particularidades', validators=[Optional()])
@@ -130,9 +141,20 @@ class DepartamentoContabilForm(DepartamentoForm):
         ('google_chat', 'Google Chat')
     ], validators=[Optional()])
     envio_fisico = SelectMultipleField('Envio Físico', choices=[
-        ('malote', 'Malote'), ('outro', 'Outro')
+        ('malote', 'Malote')
     ], validators=[Optional()])
-    envio_fisico_outro = StringField('Outro', validators=[Optional()])
+    malote_movimento = SelectField(
+        'Movimento Físico',
+        choices=[
+            ('', 'Selecione'),
+            ('eles_trazem', 'Eles trazem'),
+            ('nos_buscamos', 'Nós buscamos')
+        ],
+        validators=[Optional()]
+    )
+    def validate_malote_movimento(form, field):
+        if 'malote' in (form.envio_fisico.data or []) and not field.data:
+            raise ValidationError('Selecione uma opção para o malote')
     controle_relatorios = SelectMultipleField('Controle por Relatórios', choices=[
         ('forn_cli_cota_unica', 'Fornecedor e clientes cota única'),
         ('saldo_final_mes', 'Relatório com saldo final do mês'),

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -81,7 +81,7 @@ class Departamento(db.Model):
     forma_movimento = db.Column(db.String(20))
     envio_digital = db.Column(JsonString(200))
     envio_fisico = db.Column(JsonString(200))
-    envio_fisico_outro = db.Column(db.String(200))
+    malote_movimento = db.Column(db.String(20))
     observacao_movimento = db.Column(db.String(200))
     metodo_importacao = db.Column(db.String(20))
     controle_relatorios = db.Column(JsonString(255))

--- a/app/static/javascript/forma_movimento.js
+++ b/app/static/javascript/forma_movimento.js
@@ -37,20 +37,25 @@ function setupFormaMovimento(selectId, digitalId, fisicoId) {
     update();
 }
 
-function setupFisicoOutro(containerId) {
+function setupMaloteMovimento(containerId) {
     const container = document.getElementById(containerId);
     if (!container) return;
-    const outroCheckbox = container.querySelector('input[value="outro"]');
-    const outroInput = container.querySelector('.outro-input');
-    if (!outroCheckbox || !outroInput) return;
-    function toggleOutro() {
-        if (outroCheckbox.checked) {
-            outroInput.style.display = '';
+    const maloteCheckbox = container.querySelector('input[value="malote"]');
+    const movimentoField = container.querySelector('.malote-movimento-field');
+    if (!maloteCheckbox || !movimentoField) return;
+    const movimentoSelect = movimentoField.querySelector('select');
+    function toggleMovimento() {
+        if (maloteCheckbox.checked) {
+            movimentoField.style.display = '';
+            if (movimentoSelect) movimentoSelect.setAttribute('required', 'required');
         } else {
-            outroInput.style.display = 'none';
-            outroInput.value = '';
+            movimentoField.style.display = 'none';
+            if (movimentoSelect) {
+                movimentoSelect.value = '';
+                movimentoSelect.removeAttribute('required');
+            }
         }
     }
-    outroCheckbox.addEventListener('change', toggleOutro);
-    toggleOutro();
+    maloteCheckbox.addEventListener('change', toggleMovimento);
+    toggleMovimento();
 }

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -75,7 +75,10 @@
                                 </div>
                                 {% endfor %}
                             </div>
-                            <input type="text" class="form-control mt-2 outro-input" id="envio_fisico_outro" name="{{ form.envio_fisico_outro.name }}" placeholder="Descreva outro" value="{{ form.envio_fisico_outro.data or '' }}" style="display: none;">
+                            <div class="malote-movimento-field mt-3" style="display:none;">
+                                <label class="form-label fw-semibold">{{ form.malote_movimento.label.text }}</label>
+                                {{ form.malote_movimento(class="form-select malote-movimento") }}
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -242,7 +245,7 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     setupFormaMovimento('forma_movimento', 'envio_digital_container', 'envio_fisico_container');
-    setupFisicoOutro('envio_fisico_container');
+    setupMaloteMovimento('envio_fisico_container');
 
     document.querySelector('form').addEventListener('submit', function (e) {
         const particularidadesField = document.querySelector('#particularidades');

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -105,7 +105,10 @@
                                 </div>
                                 {% endfor %}
                             </div>
-                            <input type="text" class="form-control mt-2 outro-input" id="envio_fisico_outro" name="{{ form.envio_fisico_outro.name }}" placeholder="Descreva outro" value="{{ form.envio_fisico_outro.data or '' }}" style="display: none;">
+                            <div class="malote-movimento-field mt-3" style="display:none;">
+                                <label class="form-label fw-semibold">{{ form.malote_movimento.label.text }}</label>
+                                {{ form.malote_movimento(class="form-select malote-movimento") }}
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -273,7 +276,7 @@ document.addEventListener("DOMContentLoaded", function () {
     setupContatos('contatos-container', 'add-contato', 'contatos_json');
     setupPrefeituras('links-prefeitura-container', 'add-prefeitura', 'links_prefeitura_json');
     setupFormaMovimento('forma_movimento', 'envio_digital_container', 'envio_fisico_container');
-    setupFisicoOutro('envio_fisico_container');
+    setupMaloteMovimento('envio_fisico_container');
 
     document.querySelector('form').addEventListener('submit', function (e) {
         const particularidadesField = document.querySelector('#particularidades');

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -105,7 +105,10 @@
                                 </div>
                                 {% endfor %}
                             </div>
-                            <input type="text" class="form-control mt-2 outro-input" id="fiscal_envio_fisico_outro" name="{{ fiscal_form.envio_fisico_outro.name }}" value="{{ fiscal_form.envio_fisico_outro.data or '' }}" placeholder="Descreva outro" style="display: none;">
+                            <div class="malote-movimento-field mt-3" style="display:none;">
+                                <label class="form-label fw-semibold">{{ fiscal_form.malote_movimento.label.text }}</label>
+                                {{ fiscal_form.malote_movimento(class="form-select malote-movimento") }}
+                            </div>
                             </div>
                         </div>
 
@@ -185,7 +188,10 @@
                                 </div>
                                 {% endfor %}
                             </div>
-                            <input type="text" class="form-control mt-2 outro-input" id="contabil_envio_fisico_outro" name="{{ contabil_form.envio_fisico_outro.name }}" value="{{ contabil_form.envio_fisico_outro.data or '' }}" placeholder="Descreva outro" style="display: none;">
+                            <div class="malote-movimento-field mt-3" style="display:none;">
+                                <label class="form-label fw-semibold">{{ contabil_form.malote_movimento.label.text }}</label>
+                                {{ contabil_form.malote_movimento(class="form-select malote-movimento") }}
+                            </div>
                             </div>
                         </div>
                 </div>
@@ -341,8 +347,8 @@ document.addEventListener("DOMContentLoaded", function () {
     setupPrefeituras('links-prefeitura-container', 'add-prefeitura', 'links_prefeitura_json');
     setupFormaMovimento('fiscal_forma_movimento', 'fiscal_envio_digital', 'fiscal_envio_fisico');
     setupFormaMovimento('contabil_forma_movimento', 'contabil_envio_digital', 'contabil_envio_fisico');
-    setupFisicoOutro('fiscal_envio_fisico');
-    setupFisicoOutro('contabil_envio_fisico');
+    setupMaloteMovimento('fiscal_envio_fisico');
+    setupMaloteMovimento('contabil_envio_fisico');
 
     // -- LÓGICA DO EDITOR QUILL COM UPLOAD --
     

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -177,14 +177,19 @@
                                 <label class="info-label">Envio Físico</label>
                                 <div class="info-value">
                                     {% set placeholder_env_fisico %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-inbox fs-3 mb-2"></i><p class="mb-0 small">Não configurado</p></div>{% endset %}
-                                    {% set fisico_list = fiscal.envio_fisico %}
-                                    {% if fisico_list is string %}
-                                        {% set fisico_list = [fisico_list] %}
-                                    {% elif not fisico_list %}
-                                        {% set fisico_list = [] %}
+                                    {% set fisico_list = [] %}
+                                    {% set fisico = fiscal.envio_fisico %}
+                                    {% if fisico is string %}
+                                        {% set fisico = [fisico] %}
                                     {% endif %}
-                                    {% if fiscal.envio_fisico_outro %}
-                                        {% set fisico_list = fisico_list + [fiscal.envio_fisico_outro] %}
+                                    {% if 'malote' in (fisico or []) %}
+                                        {% if fiscal.malote_movimento == 'eles_trazem' %}
+                                            {% set fisico_list = ['Malote - Eles trazem'] %}
+                                        {% elif fiscal.malote_movimento == 'nos_buscamos' %}
+                                            {% set fisico_list = ['Malote - Nós buscamos'] %}
+                                        {% else %}
+                                            {% set fisico_list = ['Malote'] %}
+                                        {% endif %}
                                     {% endif %}
                                     {{ render_badge_list(fisico_list, 'bg-dept-blue-subtle', 'bi-inbox', placeholder_env_fisico) }}
                                 </div>
@@ -317,16 +322,21 @@
                                 <label class="info-label">Envio Físico</label>
                                 <div class="info-value">
                                     {% set placeholder_cont_fisico %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-inbox fs-3 mb-2"></i><p class="mb-0 small">Não configurado</p></div>{% endset %}
+                                    {% set cont_fisico_list = [] %}
                                     {% set cont_fisico = contabil.envio_fisico %}
                                     {% if cont_fisico is string %}
                                         {% set cont_fisico = [cont_fisico] %}
-                                    {% elif not cont_fisico %}
-                                        {% set cont_fisico = [] %}
                                     {% endif %}
-                                    {% if contabil.envio_fisico_outro %}
-                                        {% set cont_fisico = cont_fisico + [contabil.envio_fisico_outro] %}
+                                    {% if 'malote' in (cont_fisico or []) %}
+                                        {% if contabil.malote_movimento == 'eles_trazem' %}
+                                            {% set cont_fisico_list = ['Malote - Eles trazem'] %}
+                                        {% elif contabil.malote_movimento == 'nos_buscamos' %}
+                                            {% set cont_fisico_list = ['Malote - Nós buscamos'] %}
+                                        {% else %}
+                                            {% set cont_fisico_list = ['Malote'] %}
+                                        {% endif %}
                                     {% endif %}
-                                    {{ render_badge_list(cont_fisico, 'bg-dept-orange-subtle', 'bi-inbox', placeholder_cont_fisico) }}
+                                    {{ render_badge_list(cont_fisico_list, 'bg-dept-orange-subtle', 'bi-inbox', placeholder_cont_fisico) }}
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- drop "Outro" option from physical delivery selections
- add required malote movement selector ("Eles trazem" or "Nós buscamos")
- show chosen malote movement in company views and handle logic in JS/routes

## Testing
- `python -m py_compile app/forms.py app/models/tables.py app/controllers/routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689de457167883308c9dd777e8362df0