### PR TITLE
Remove opção 'Outro' e adiciona escolha de malote

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -249,7 +249,7 @@ def processar_dados_fiscal(request):
     formas_importacao = json.loads(formas_importacao_json) if formas_importacao_json else []
     envio_digital = request.form.getlist('envio_digital')
     envio_fisico = request.form.getlist('envio_fisico')
-    envio_fisico_outro = request.form.get('envio_fisico_outro')
+    envio_malote = request.form.get('envio_malote')
     contatos_json = request.form.get('contatos_json', 'null')
     contatos = json.loads(contatos_json) if contatos_json != 'null' else None
     if contatos is not None:
@@ -263,7 +263,7 @@ def processar_dados_fiscal(request):
         'forma_movimento': forma_movimento,
         'envio_digital': envio_digital,
         'envio_fisico': envio_fisico,
-        'envio_fisico_outro': envio_fisico_outro,
+        'envio_malote': envio_malote,
         'observacao_movimento': observacao_movimento,
         'contatos': contatos,
         'particularidades_texto': particularidades
@@ -278,7 +278,7 @@ def processar_dados_contabil(request):
     particularidades = request.form.get('particularidades')
     envio_digital = request.form.getlist('envio_digital')
     envio_fisico = request.form.getlist('envio_fisico')
-    envio_fisico_outro = request.form.get('envio_fisico_outro')
+    envio_malote = request.form.get('envio_malote')
     controle_relatorios_json = request.form.get('controle_relatorios_json', '[]')
     controle_relatorios = json.loads(controle_relatorios_json) if controle_relatorios_json else []
     
@@ -289,7 +289,7 @@ def processar_dados_contabil(request):
         'forma_movimento': forma_movimento,
         'envio_digital': envio_digital,
         'envio_fisico': envio_fisico,
-        'envio_fisico_outro': envio_fisico_outro,
+        'envio_malote': envio_malote,
         'controle_relatorios': controle_relatorios,
         'particularidades_texto': particularidades
     }
@@ -471,7 +471,7 @@ def gerenciar_departamentos(empresa_id):
                 contabil_form.envio_fisico.data = json.loads(contabil.envio_fisico) if contabil.envio_fisico else []
             except Exception:
                 contabil_form.envio_fisico.data = []
-            contabil_form.envio_fisico_outro.data = contabil.envio_fisico_outro
+            contabil_form.envio_malote.data = contabil.envio_malote
             
             try:
                 contabil_form.controle_relatorios.data = json.loads(contabil.controle_relatorios) if contabil.controle_relatorios else []
@@ -509,7 +509,7 @@ def gerenciar_departamentos(empresa_id):
 
             contabil.envio_digital = json.dumps(contabil_form.envio_digital.data or [])
             contabil.envio_fisico = json.dumps(contabil_form.envio_fisico.data or [])
-            contabil.envio_fisico_outro = contabil_form.envio_fisico_outro.data
+            contabil.envio_malote = contabil_form.envio_malote.data
             contabil.controle_relatorios = json.dumps(contabil_form.controle_relatorios.data or [])
             
             flash('Departamento Contábil salvo com sucesso!', 'success')

--- a/app/forms.py
+++ b/app/forms.py
@@ -110,9 +110,13 @@ class DepartamentoFiscalForm(DepartamentoForm):
         ('google_chat', 'Google Chat')
     ], validators=[Optional()])
     envio_fisico = SelectMultipleField('Envio Físico', choices=[
-        ('malote', 'Malote'), ('outro', 'Outro')
+        ('malote', 'Malote')
     ], validators=[Optional()])
-    envio_fisico_outro = StringField('Outro', validators=[Optional()])
+    envio_malote = SelectField('Malote', choices=[
+        ('', 'Selecione'),
+        ('Eles Trazem', 'Eles Trazem'),
+        ('Nós Buscamos', 'Nós Buscamos')
+    ], validators=[Optional()])
     observacao_movimento = TextAreaField('Observação', validators=[Optional()])
     contatos_json = HiddenField('Contatos', validators=[Optional()])
     particularidades_texto = TextAreaField('Particularidades', validators=[Optional()])
@@ -130,9 +134,13 @@ class DepartamentoContabilForm(DepartamentoForm):
         ('google_chat', 'Google Chat')
     ], validators=[Optional()])
     envio_fisico = SelectMultipleField('Envio Físico', choices=[
-        ('malote', 'Malote'), ('outro', 'Outro')
+        ('malote', 'Malote')
     ], validators=[Optional()])
-    envio_fisico_outro = StringField('Outro', validators=[Optional()])
+    envio_malote = SelectField('Malote', choices=[
+        ('', 'Selecione'),
+        ('Eles Trazem', 'Eles Trazem'),
+        ('Nós Buscamos', 'Nós Buscamos')
+    ], validators=[Optional()])
     controle_relatorios = SelectMultipleField('Controle por Relatórios', choices=[
         ('forn_cli_cota_unica', 'Fornecedor e clientes cota única'),
         ('saldo_final_mes', 'Relatório com saldo final do mês'),

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -81,7 +81,7 @@ class Departamento(db.Model):
     forma_movimento = db.Column(db.String(20))
     envio_digital = db.Column(JsonString(200))
     envio_fisico = db.Column(JsonString(200))
-    envio_fisico_outro = db.Column(db.String(200))
+    envio_malote = db.Column(db.String(50))
     observacao_movimento = db.Column(db.String(200))
     metodo_importacao = db.Column(db.String(20))
     controle_relatorios = db.Column(JsonString(255))

--- a/app/static/javascript/forma_movimento.js
+++ b/app/static/javascript/forma_movimento.js
@@ -10,6 +10,8 @@ function setupFormaMovimento(selectId, digitalId, fisicoId) {
         checkboxes.forEach(cb => cb.checked = false);
         const textInputs = container.querySelectorAll('input[type="text"]');
         textInputs.forEach(input => input.value = '');
+        const selects = container.querySelectorAll('select');
+        selects.forEach(sel => sel.value = '');
     }
 
     function update() {
@@ -37,20 +39,20 @@ function setupFormaMovimento(selectId, digitalId, fisicoId) {
     update();
 }
 
-function setupFisicoOutro(containerId) {
+function setupMaloteSelect(containerId) {
     const container = document.getElementById(containerId);
     if (!container) return;
-    const outroCheckbox = container.querySelector('input[value="outro"]');
-    const outroInput = container.querySelector('.outro-input');
-    if (!outroCheckbox || !outroInput) return;
-    function toggleOutro() {
-        if (outroCheckbox.checked) {
-            outroInput.style.display = '';
+    const maloteCheckbox = container.querySelector('input[value="malote"]');
+    const maloteSelect = container.querySelector('.malote-select');
+    if (!maloteCheckbox || !maloteSelect) return;
+    function toggleMalote() {
+        if (maloteCheckbox.checked) {
+            maloteSelect.style.display = '';
         } else {
-            outroInput.style.display = 'none';
-            outroInput.value = '';
+            maloteSelect.style.display = 'none';
+            maloteSelect.value = '';
         }
     }
-    outroCheckbox.addEventListener('change', toggleOutro);
-    toggleOutro();
+    maloteCheckbox.addEventListener('change', toggleMalote);
+    toggleMalote();
 }

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -75,7 +75,11 @@
                                 </div>
                                 {% endfor %}
                             </div>
-                            <input type="text" class="form-control mt-2 outro-input" id="envio_fisico_outro" name="{{ form.envio_fisico_outro.name }}" placeholder="Descreva outro" value="{{ form.envio_fisico_outro.data or '' }}" style="display: none;">
+                            <select class="form-select mt-2 malote-select" id="envio_malote" name="{{ form.envio_malote.name }}" style="display: none;">
+                                {% for value, label in form.envio_malote.choices %}
+                                <option value="{{ value }}" {% if form.envio_malote.data == value %}selected{% endif %}>{{ label }}</option>
+                                {% endfor %}
+                            </select>
                         </div>
                     </div>
                 </div>
@@ -242,7 +246,7 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     setupFormaMovimento('forma_movimento', 'envio_digital_container', 'envio_fisico_container');
-    setupFisicoOutro('envio_fisico_container');
+    setupMaloteSelect('envio_fisico_container');
 
     document.querySelector('form').addEventListener('submit', function (e) {
         const particularidadesField = document.querySelector('#particularidades');

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -105,7 +105,11 @@
                                 </div>
                                 {% endfor %}
                             </div>
-                            <input type="text" class="form-control mt-2 outro-input" id="envio_fisico_outro" name="{{ form.envio_fisico_outro.name }}" placeholder="Descreva outro" value="{{ form.envio_fisico_outro.data or '' }}" style="display: none;">
+                            <select class="form-select mt-2 malote-select" id="envio_malote" name="{{ form.envio_malote.name }}" style="display: none;">
+                                {% for value, label in form.envio_malote.choices %}
+                                <option value="{{ value }}" {% if form.envio_malote.data == value %}selected{% endif %}>{{ label }}</option>
+                                {% endfor %}
+                            </select>
                         </div>
                     </div>
                 </div>
@@ -273,7 +277,7 @@ document.addEventListener("DOMContentLoaded", function () {
     setupContatos('contatos-container', 'add-contato', 'contatos_json');
     setupPrefeituras('links-prefeitura-container', 'add-prefeitura', 'links_prefeitura_json');
     setupFormaMovimento('forma_movimento', 'envio_digital_container', 'envio_fisico_container');
-    setupFisicoOutro('envio_fisico_container');
+    setupMaloteSelect('envio_fisico_container');
 
     document.querySelector('form').addEventListener('submit', function (e) {
         const particularidadesField = document.querySelector('#particularidades');

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -105,7 +105,11 @@
                                 </div>
                                 {% endfor %}
                             </div>
-                            <input type="text" class="form-control mt-2 outro-input" id="fiscal_envio_fisico_outro" name="{{ fiscal_form.envio_fisico_outro.name }}" value="{{ fiscal_form.envio_fisico_outro.data or '' }}" placeholder="Descreva outro" style="display: none;">
+                            <select class="form-select mt-2 malote-select" id="fiscal_envio_malote" name="{{ fiscal_form.envio_malote.name }}" style="display: none;">
+                                {% for value, label in fiscal_form.envio_malote.choices %}
+                                <option value="{{ value }}" {% if fiscal_form.envio_malote.data == value %}selected{% endif %}>{{ label }}</option>
+                                {% endfor %}
+                            </select>
                             </div>
                         </div>
 
@@ -185,7 +189,11 @@
                                 </div>
                                 {% endfor %}
                             </div>
-                            <input type="text" class="form-control mt-2 outro-input" id="contabil_envio_fisico_outro" name="{{ contabil_form.envio_fisico_outro.name }}" value="{{ contabil_form.envio_fisico_outro.data or '' }}" placeholder="Descreva outro" style="display: none;">
+                            <select class="form-select mt-2 malote-select" id="contabil_envio_malote" name="{{ contabil_form.envio_malote.name }}" style="display: none;">
+                                {% for value, label in contabil_form.envio_malote.choices %}
+                                <option value="{{ value }}" {% if contabil_form.envio_malote.data == value %}selected{% endif %}>{{ label }}</option>
+                                {% endfor %}
+                            </select>
                             </div>
                         </div>
                 </div>
@@ -341,8 +349,8 @@ document.addEventListener("DOMContentLoaded", function () {
     setupPrefeituras('links-prefeitura-container', 'add-prefeitura', 'links_prefeitura_json');
     setupFormaMovimento('fiscal_forma_movimento', 'fiscal_envio_digital', 'fiscal_envio_fisico');
     setupFormaMovimento('contabil_forma_movimento', 'contabil_envio_digital', 'contabil_envio_fisico');
-    setupFisicoOutro('fiscal_envio_fisico');
-    setupFisicoOutro('contabil_envio_fisico');
+    setupMaloteSelect('fiscal_envio_fisico');
+    setupMaloteSelect('contabil_envio_fisico');
 
     // -- LÓGICA DO EDITOR QUILL COM UPLOAD --
     

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -177,15 +177,20 @@
                                 <label class="info-label">Envio Físico</label>
                                 <div class="info-value">
                                     {% set placeholder_env_fisico %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-inbox fs-3 mb-2"></i><p class="mb-0 small">Não configurado</p></div>{% endset %}
-                                    {% set fisico_list = fiscal.envio_fisico %}
-                                    {% if fisico_list is string %}
-                                        {% set fisico_list = [fisico_list] %}
-                                    {% elif not fisico_list %}
-                                        {% set fisico_list = [] %}
+                                    {% set fisico_base = fiscal.envio_fisico %}
+                                    {% if fisico_base is string %}
+                                        {% set fisico_base = [fisico_base] %}
+                                    {% elif not fisico_base %}
+                                        {% set fisico_base = [] %}
                                     {% endif %}
-                                    {% if fiscal.envio_fisico_outro %}
-                                        {% set fisico_list = fisico_list + [fiscal.envio_fisico_outro] %}
-                                    {% endif %}
+                                    {% set fisico_list = [] %}
+                                    {% for item in fisico_base %}
+                                        {% if item == 'malote' and fiscal.envio_malote %}
+                                            {% set fisico_list = fisico_list + ['Malote - ' ~ fiscal.envio_malote] %}
+                                        {% else %}
+                                            {% set fisico_list = fisico_list + [item] %}
+                                        {% endif %}
+                                    {% endfor %}
                                     {{ render_badge_list(fisico_list, 'bg-dept-blue-subtle', 'bi-inbox', placeholder_env_fisico) }}
                                 </div>
                             </div>
@@ -317,15 +322,20 @@
                                 <label class="info-label">Envio Físico</label>
                                 <div class="info-value">
                                     {% set placeholder_cont_fisico %}<div class="text-center text-muted py-3 border rounded bg-light"><i class="bi bi-inbox fs-3 mb-2"></i><p class="mb-0 small">Não configurado</p></div>{% endset %}
-                                    {% set cont_fisico = contabil.envio_fisico %}
-                                    {% if cont_fisico is string %}
-                                        {% set cont_fisico = [cont_fisico] %}
-                                    {% elif not cont_fisico %}
-                                        {% set cont_fisico = [] %}
+                                    {% set cont_base = contabil.envio_fisico %}
+                                    {% if cont_base is string %}
+                                        {% set cont_base = [cont_base] %}
+                                    {% elif not cont_base %}
+                                        {% set cont_base = [] %}
                                     {% endif %}
-                                    {% if contabil.envio_fisico_outro %}
-                                        {% set cont_fisico = cont_fisico + [contabil.envio_fisico_outro] %}
-                                    {% endif %}
+                                    {% set cont_fisico = [] %}
+                                    {% for item in cont_base %}
+                                        {% if item == 'malote' and contabil.envio_malote %}
+                                            {% set cont_fisico = cont_fisico + ['Malote - ' ~ contabil.envio_malote] %}
+                                        {% else %}
+                                            {% set cont_fisico = cont_fisico + [item] %}
+                                        {% endif %}
+                                    {% endfor %}
                                     {{ render_badge_list(cont_fisico, 'bg-dept-orange-subtle', 'bi-inbox', placeholder_cont_fisico) }}
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- remove a opção "Outro" dos envios físicos
- adiciona seleção de malote com "Eles Trazem" e "Nós Buscamos"
- atualiza scripts para exibir a seleção apenas quando "Malote" estiver marcado

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689df499dd188330a1197f1b1e0d9ef2