### PR TITLE
Remover opção "Outro" do envio físico

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -249,7 +249,6 @@ def processar_dados_fiscal(request):
     formas_importacao = json.loads(formas_importacao_json) if formas_importacao_json else []
     envio_digital = request.form.getlist('envio_digital')
     envio_fisico = request.form.getlist('envio_fisico')
-    envio_fisico_outro = request.form.get('envio_fisico_outro')
     contatos_json = request.form.get('contatos_json', 'null')
     contatos = json.loads(contatos_json) if contatos_json != 'null' else None
     if contatos is not None:
@@ -263,7 +262,6 @@ def processar_dados_fiscal(request):
         'forma_movimento': forma_movimento,
         'envio_digital': envio_digital,
         'envio_fisico': envio_fisico,
-        'envio_fisico_outro': envio_fisico_outro,
         'observacao_movimento': observacao_movimento,
         'contatos': contatos,
         'particularidades_texto': particularidades
@@ -278,7 +276,6 @@ def processar_dados_contabil(request):
     particularidades = request.form.get('particularidades')
     envio_digital = request.form.getlist('envio_digital')
     envio_fisico = request.form.getlist('envio_fisico')
-    envio_fisico_outro = request.form.get('envio_fisico_outro')
     controle_relatorios_json = request.form.get('controle_relatorios_json', '[]')
     controle_relatorios = json.loads(controle_relatorios_json) if controle_relatorios_json else []
     
@@ -289,7 +286,6 @@ def processar_dados_contabil(request):
         'forma_movimento': forma_movimento,
         'envio_digital': envio_digital,
         'envio_fisico': envio_fisico,
-        'envio_fisico_outro': envio_fisico_outro,
         'controle_relatorios': controle_relatorios,
         'particularidades_texto': particularidades
     }
@@ -471,7 +467,6 @@ def gerenciar_departamentos(empresa_id):
                 contabil_form.envio_fisico.data = json.loads(contabil.envio_fisico) if contabil.envio_fisico else []
             except Exception:
                 contabil_form.envio_fisico.data = []
-            contabil_form.envio_fisico_outro.data = contabil.envio_fisico_outro
             
             try:
                 contabil_form.controle_relatorios.data = json.loads(contabil.controle_relatorios) if contabil.controle_relatorios else []
@@ -509,7 +504,6 @@ def gerenciar_departamentos(empresa_id):
 
             contabil.envio_digital = json.dumps(contabil_form.envio_digital.data or [])
             contabil.envio_fisico = json.dumps(contabil_form.envio_fisico.data or [])
-            contabil.envio_fisico_outro = contabil_form.envio_fisico_outro.data
             contabil.controle_relatorios = json.dumps(contabil_form.controle_relatorios.data or [])
             
             flash('Departamento Contábil salvo com sucesso!', 'success')

--- a/app/forms.py
+++ b/app/forms.py
@@ -110,9 +110,8 @@ class DepartamentoFiscalForm(DepartamentoForm):
         ('google_chat', 'Google Chat')
     ], validators=[Optional()])
     envio_fisico = SelectMultipleField('Envio Físico', choices=[
-        ('malote', 'Malote'), ('outro', 'Outro')
+        ('malote', 'Malote')
     ], validators=[Optional()])
-    envio_fisico_outro = StringField('Outro', validators=[Optional()])
     observacao_movimento = TextAreaField('Observação', validators=[Optional()])
     contatos_json = HiddenField('Contatos', validators=[Optional()])
     particularidades_texto = TextAreaField('Particularidades', validators=[Optional()])
@@ -130,9 +129,8 @@ class DepartamentoContabilForm(DepartamentoForm):
         ('google_chat', 'Google Chat')
     ], validators=[Optional()])
     envio_fisico = SelectMultipleField('Envio Físico', choices=[
-        ('malote', 'Malote'), ('outro', 'Outro')
+        ('malote', 'Malote')
     ], validators=[Optional()])
-    envio_fisico_outro = StringField('Outro', validators=[Optional()])
     controle_relatorios = SelectMultipleField('Controle por Relatórios', choices=[
         ('forn_cli_cota_unica', 'Fornecedor e clientes cota única'),
         ('saldo_final_mes', 'Relatório com saldo final do mês'),

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -81,7 +81,6 @@ class Departamento(db.Model):
     forma_movimento = db.Column(db.String(20))
     envio_digital = db.Column(JsonString(200))
     envio_fisico = db.Column(JsonString(200))
-    envio_fisico_outro = db.Column(db.String(200))
     observacao_movimento = db.Column(db.String(200))
     metodo_importacao = db.Column(db.String(20))
     controle_relatorios = db.Column(JsonString(255))

--- a/app/static/javascript/forma_movimento.js
+++ b/app/static/javascript/forma_movimento.js
@@ -36,21 +36,3 @@ function setupFormaMovimento(selectId, digitalId, fisicoId) {
     select.addEventListener('change', update);
     update();
 }
-
-function setupFisicoOutro(containerId) {
-    const container = document.getElementById(containerId);
-    if (!container) return;
-    const outroCheckbox = container.querySelector('input[value="outro"]');
-    const outroInput = container.querySelector('.outro-input');
-    if (!outroCheckbox || !outroInput) return;
-    function toggleOutro() {
-        if (outroCheckbox.checked) {
-            outroInput.style.display = '';
-        } else {
-            outroInput.style.display = 'none';
-            outroInput.value = '';
-        }
-    }
-    outroCheckbox.addEventListener('change', toggleOutro);
-    toggleOutro();
-}

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -75,7 +75,6 @@
                                 </div>
                                 {% endfor %}
                             </div>
-                            <input type="text" class="form-control mt-2 outro-input" id="envio_fisico_outro" name="{{ form.envio_fisico_outro.name }}" placeholder="Descreva outro" value="{{ form.envio_fisico_outro.data or '' }}" style="display: none;">
                         </div>
                     </div>
                 </div>
@@ -242,7 +241,6 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     setupFormaMovimento('forma_movimento', 'envio_digital_container', 'envio_fisico_container');
-    setupFisicoOutro('envio_fisico_container');
 
     document.querySelector('form').addEventListener('submit', function (e) {
         const particularidadesField = document.querySelector('#particularidades');

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -105,7 +105,6 @@
                                 </div>
                                 {% endfor %}
                             </div>
-                            <input type="text" class="form-control mt-2 outro-input" id="envio_fisico_outro" name="{{ form.envio_fisico_outro.name }}" placeholder="Descreva outro" value="{{ form.envio_fisico_outro.data or '' }}" style="display: none;">
                         </div>
                     </div>
                 </div>
@@ -273,7 +272,6 @@ document.addEventListener("DOMContentLoaded", function () {
     setupContatos('contatos-container', 'add-contato', 'contatos_json');
     setupPrefeituras('links-prefeitura-container', 'add-prefeitura', 'links_prefeitura_json');
     setupFormaMovimento('forma_movimento', 'envio_digital_container', 'envio_fisico_container');
-    setupFisicoOutro('envio_fisico_container');
 
     document.querySelector('form').addEventListener('submit', function (e) {
         const particularidadesField = document.querySelector('#particularidades');

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -105,7 +105,6 @@
                                 </div>
                                 {% endfor %}
                             </div>
-                            <input type="text" class="form-control mt-2 outro-input" id="fiscal_envio_fisico_outro" name="{{ fiscal_form.envio_fisico_outro.name }}" value="{{ fiscal_form.envio_fisico_outro.data or '' }}" placeholder="Descreva outro" style="display: none;">
                             </div>
                         </div>
 
@@ -185,7 +184,6 @@
                                 </div>
                                 {% endfor %}
                             </div>
-                            <input type="text" class="form-control mt-2 outro-input" id="contabil_envio_fisico_outro" name="{{ contabil_form.envio_fisico_outro.name }}" value="{{ contabil_form.envio_fisico_outro.data or '' }}" placeholder="Descreva outro" style="display: none;">
                             </div>
                         </div>
                 </div>
@@ -341,8 +339,6 @@ document.addEventListener("DOMContentLoaded", function () {
     setupPrefeituras('links-prefeitura-container', 'add-prefeitura', 'links_prefeitura_json');
     setupFormaMovimento('fiscal_forma_movimento', 'fiscal_envio_digital', 'fiscal_envio_fisico');
     setupFormaMovimento('contabil_forma_movimento', 'contabil_envio_digital', 'contabil_envio_fisico');
-    setupFisicoOutro('fiscal_envio_fisico');
-    setupFisicoOutro('contabil_envio_fisico');
 
     // -- LÓGICA DO EDITOR QUILL COM UPLOAD --
     

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -183,9 +183,6 @@
                                     {% elif not fisico_list %}
                                         {% set fisico_list = [] %}
                                     {% endif %}
-                                    {% if fiscal.envio_fisico_outro %}
-                                        {% set fisico_list = fisico_list + [fiscal.envio_fisico_outro] %}
-                                    {% endif %}
                                     {{ render_badge_list(fisico_list, 'bg-dept-blue-subtle', 'bi-inbox', placeholder_env_fisico) }}
                                 </div>
                             </div>
@@ -322,9 +319,6 @@
                                         {% set cont_fisico = [cont_fisico] %}
                                     {% elif not cont_fisico %}
                                         {% set cont_fisico = [] %}
-                                    {% endif %}
-                                    {% if contabil.envio_fisico_outro %}
-                                        {% set cont_fisico = cont_fisico + [contabil.envio_fisico_outro] %}
                                     {% endif %}
                                     {{ render_badge_list(cont_fisico, 'bg-dept-orange-subtle', 'bi-inbox', placeholder_cont_fisico) }}
                                 </div>


### PR DESCRIPTION
## Summary
- remove opção `Outro` das escolhas de envio físico, mantendo apenas `Malote`
- elimina campo `envio_fisico_outro` de modelos, formulários, templates e scripts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e09a9ab088330a4275e98b40a9e12

## Summary by Sourcery

Enhancements:
- Eliminate envio_fisico_outro field and its handling across forms, controllers, templates, JavaScript, and the database