### PR TITLE
Exibir tributação na lista de empresas

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -12,7 +12,6 @@ from app.forms import (
     DepartamentoContabilForm,
     DepartamentoPessoalForm,
 )
-from datetime import datetime
 import os, json, re
 from werkzeug.utils import secure_filename
 from uuid import uuid4
@@ -223,13 +222,6 @@ def listar_empresas():
         )
 
     empresas = query.all()
-
-    for empresa in empresas:
-        if empresa.data_abertura and isinstance(empresa.data_abertura, str):
-            try:
-                empresa.data_abertura = datetime.strptime(empresa.data_abertura, '%d-%m-%Y')
-            except ValueError:
-                empresa.data_abertura = None
 
     return render_template('empresas/listar.html', empresas=empresas, search=search)
 

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -101,7 +101,7 @@ Tabelas (Empresas e Usuários)
 
 .user-table, .table-empresas {
     width: 100%;
-    max-width: 1000px;
+    max-width: 1200px;
     margin: 0 auto;
     border-collapse: collapse;
 }
@@ -131,6 +131,10 @@ Tabelas (Empresas e Usuários)
 }
 
 .cnpj-col {
+    width: 160px;
+}
+
+.tributacao-col {
     width: 160px;
 }
 

--- a/app/templates/empresas/listar.html
+++ b/app/templates/empresas/listar.html
@@ -3,7 +3,7 @@
 {% block title %}Empresas Cadastradas{% endblock %}
 
 {% block content %}
-<div class="container mt-4" style="max-width: 1000px;">
+<div class="container mt-4" style="max-width: 1200px;">
     <!-- Cabeçalho da Página -->
     <div class="row mb-4">
         <div class="col-12">
@@ -53,7 +53,7 @@
                             <th class="codigo-col">Código</th>
                             <th>Nome da Empresa</th>
                             <th class="cnpj-col">CNPJ</th>
-                            <th>Data Abertura</th>
+                            <th class="tributacao-col">Tributação</th>
                             <th class="acao-col">Ações</th>
                         </tr>
                     </thead>
@@ -79,10 +79,12 @@
                             <td class="cnpj-col">
                                 <span class="font-monospace cnpj-formatted">{{ empresa.cnpj }}</span>
                             </td>
-                            <td>
-                                <span class="text-muted">
-                                    {{ empresa.data_abertura.strftime('%d/%m/%Y') if empresa.data_abertura else 'N/A' }}
-                                </span>
+                            <td class="tributacao-col">
+                                {% if empresa.tributacao %}
+                                <span class="badge bg-success-subtle text-success">{{ empresa.tributacao }}</span>
+                                {% else %}
+                                <span class="text-muted">N/A</span>
+                                {% endif %}
                             </td>
                             <td class="acao-col">
                                 <a href="{{ url_for('gerenciar_departamentos', empresa_id=empresa.id) }}" 


### PR DESCRIPTION
## Summary
- mostrar o campo de tributação na listagem de empresas
- remover coluna de data de abertura e ajustar largura da tabela
- limpar backend removendo processamento desnecessário da data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e252188088330a45e67890416e45e

## Summary by Sourcery

Display the taxation field in the company list, remove the deprecated opening date handling, and adjust layout widths and styling

New Features:
- Add taxation column to the companies list with badge and N/A fallback

Enhancements:
- Remove unnecessary backend processing of the opening date