### PR TITLE
Fix department management link in company view

### DIFF
--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -277,7 +277,7 @@
     {% else %}
         <div class="card shadow-lg mb-5" style="border-color:#0b288b;">
             <div class="card-header bg-dept-blue text-white py-3"><h3 class="mb-0 fw-semibold"><i class="bi bi-receipt me-2"></i>Departamento Fiscal</h3></div>
-            <div class="card-body p-4 text-center"><div class="py-5"><i class="bi bi-exclamation-triangle-fill fs-1 text-dept-blue mb-3"></i><h5 class="text-muted">Departamento Fiscal não configurado</h5><p class="text-muted mb-4">Este departamento ainda não foi configurado.</p><a href="{{ url_for('editar_empresa', id=empresa.id) }}#fiscal" class="btn btn-dept-blue"><i class="bi bi-plus-circle me-2"></i>Configurar</a></div></div>
+            <div class="card-body p-4 text-center"><div class="py-5"><i class="bi bi-exclamation-triangle-fill fs-1 text-dept-blue mb-3"></i><h5 class="text-muted">Departamento Fiscal não configurado</h5><p class="text-muted mb-4">Este departamento ainda não foi configurado.</p><a href="{{ url_for('gerenciar_departamentos', empresa_id=empresa.id) }}#fiscal" class="btn btn-dept-blue"><i class="bi bi-plus-circle me-2"></i>Configurar</a></div></div>
         </div>
     {% endif %}
     </div>
@@ -369,7 +369,7 @@
     {% else %}
         <div class="card shadow-lg mb-5" style="border-color:#e87429;">
             <div class="card-header bg-dept-orange text-white py-3"><h3 class="mb-0 fw-semibold"><i class="bi bi-calculator me-2"></i>Departamento Contábil</h3></div>
-            <div class="card-body p-4 text-center"><div class="py-5"><i class="bi bi-exclamation-triangle-fill fs-1 text-dept-orange mb-3"></i><h5 class="text-muted">Departamento Contábil não configurado</h5><p class="text-muted mb-4">Este departamento ainda não foi configurado.</p><a href="{{ url_for('editar_empresa', id=empresa.id) }}#contabil" class="btn btn-dept-orange"><i class="bi bi-plus-circle me-2"></i>Configurar</a></div></div>
+            <div class="card-body p-4 text-center"><div class="py-5"><i class="bi bi-exclamation-triangle-fill fs-1 text-dept-orange mb-3"></i><h5 class="text-muted">Departamento Contábil não configurado</h5><p class="text-muted mb-4">Este departamento ainda não foi configurado.</p><a href="{{ url_for('gerenciar_departamentos', empresa_id=empresa.id) }}#contabil" class="btn btn-dept-orange"><i class="bi bi-plus-circle me-2"></i>Configurar</a></div></div>
         </div>
     {% endif %}
     </div>
@@ -448,7 +448,7 @@
         {% else %}
             <div class="card shadow-lg mb-5" style="border-color:#0b288b;">
                 <div class="card-header bg-dept-blue text-white py-3"><h3 class="mb-0 fw-semibold"><i class="bi bi-people me-2"></i>Departamento Pessoal</h3></div>
-                <div class="card-body p-4 text-center"><div class="py-5"><i class="bi bi-exclamation-triangle-fill fs-1 text-dept-blue mb-3"></i><h5 class="text-muted">Departamento Pessoal não configurado</h5><p class="text-muted mb-4">Este departamento ainda não foi configurado.</p><a href="{{ url_for('editar_empresa', id=empresa.id) }}#pessoal" class="btn btn-dept-blue"><i class="bi bi-plus-circle me-2"></i>Configurar</a></div></div>
+                <div class="card-body p-4 text-center"><div class="py-5"><i class="bi bi-exclamation-triangle-fill fs-1 text-dept-blue mb-3"></i><h5 class="text-muted">Departamento Pessoal não configurado</h5><p class="text-muted mb-4">Este departamento ainda não foi configurado.</p><a href="{{ url_for('gerenciar_departamentos', empresa_id=empresa.id) }}#pessoal" class="btn btn-dept-blue"><i class="bi bi-plus-circle me-2"></i>Configurar</a></div></div>
             </div>
         {% endif %}
         </div>
@@ -478,7 +478,7 @@
     {% else %}
         <div class="card shadow-lg mb-5" style="border-color:#e87429;">
             <div class="card-header bg-dept-orange text-white py-3"><h3 class="mb-0 fw-semibold"><i class="bi bi-gear me-2"></i>Departamento Administrativo</h3></div>
-            <div class="card-body p-4 text-center"><div class="py-5"><i class="bi bi-exclamation-triangle-fill fs-1 text-dept-orange mb-3"></i><h5 class="text-muted">Departamento Administrativo não configurado</h5><p class="text-muted mb-4">Este departamento ainda não foi configurado.</p><a href="{{ url_for('editar_empresa', id=empresa.id) }}#administrativo" class="btn btn-dept-orange"><i class="bi bi-plus-circle me-2"></i>Configurar</a></div></div>
+            <div class="card-body p-4 text-center"><div class="py-5"><i class="bi bi-exclamation-triangle-fill fs-1 text-dept-orange mb-3"></i><h5 class="text-muted">Departamento Administrativo não configurado</h5><p class="text-muted mb-4">Este departamento ainda não foi configurado.</p><a href="{{ url_for('gerenciar_departamentos', empresa_id=empresa.id) }}#administrativo" class="btn btn-dept-orange"><i class="bi bi-plus-circle me-2"></i>Configurar</a></div></div>
         </div>
     {% endif %}
     </div>
@@ -488,7 +488,7 @@
             <div class="d-flex justify-content-center gap-3 flex-wrap">
                 <a href="{{ url_for('listar_empresas') }}" class="btn btn-outline-secondary px-4"><i class="bi bi-arrow-left me-2"></i>Voltar para Lista</a>
                 <a href="{{ url_for('editar_empresa', id=empresa.id) }}" class="btn btn-primary px-4"><i class="bi bi-pencil me-2"></i>Editar Empresa</a>
-                <a href="{{ url_for('editar_empresa', id=empresa.id) }}#fiscal" class="btn btn-outline-info px-4"><i class="bi bi-diagram-3 me-2"></i>Gerenciar Departamentos</a>
+                <a href="{{ url_for('gerenciar_departamentos', empresa_id=empresa.id) }}" class="btn btn-outline-info px-4"><i class="bi bi-diagram-3 me-2"></i>Gerenciar Departamentos</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Correct department configuration links in company visualization
- Point "Gerenciar Departamentos" button to department management page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e2c1f6a708330af66538a65133236

## Summary by Sourcery

Fix department management links in company view to point to the dedicated department management page

Bug Fixes:
- Update department config buttons in company visualization to use gerenciar_departamentos route with empresa_id and appropriate anchors
- Update main 'Gerenciar Departamentos' button to link to gerenciar_departamentos route instead of edit company page