### PR TITLE
fix: prevent duplicate flash messages

### DIFF
--- a/app/templates/admin/novo_usuario.html
+++ b/app/templates/admin/novo_usuario.html
@@ -12,19 +12,6 @@
         </div>
         
         <div class="card-body p-4">
-            <!-- Mensagens Flash -->
-            {% with messages = get_flashed_messages(with_categories=true) %}
-                {% if messages %}
-                    {% for category, message in messages %}
-                        <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-                            <i class="bi bi-{{ 'exclamation-triangle' if category == 'error' else 'check-circle' }} me-2"></i>
-                            {{ message }}
-                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
-                        </div>
-                    {% endfor %}
-                {% endif %}
-            {% endwith %}
-
             <form method="POST" action="{{ url_for('novo_usuario') }}">
                 {{ form.hidden_tag() }}
 

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -19,23 +19,6 @@
         </div>
     </div>
 
-    <!-- Flash Messages -->
-    {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-            <div class="row mb-4">
-                <div class="col-12">
-                    {% for category, message in messages %}
-                        <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-                            <i class="bi bi-{{ 'exclamation-triangle-fill' if category == 'error' else 'check-circle-fill' }} me-2"></i>
-                            {{ message }}
-                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
-                        </div>
-                    {% endfor %}
-                </div>
-            </div>
-        {% endif %}
-    {% endwith %}
-
     <!-- Ações Principais -->
     <div class="row mb-5">
         {% set actions = [

--- a/app/templates/edit_user.html
+++ b/app/templates/edit_user.html
@@ -23,19 +23,6 @@
         </div>
     </div>
 
-    <!-- Mensagens Flash -->
-    {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-            {% for category, message in messages %}
-                <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-                    <i class="bi bi-{{ 'exclamation-triangle' if category == 'error' else 'check-circle' }} me-2"></i>
-                    {{ message }}
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
-                </div>
-            {% endfor %}
-        {% endif %}
-    {% endwith %}
-
     <!-- Formulário de Edição -->
     <div class="row justify-content-center">
         <div class="col-lg-8 col-xl-6">

--- a/app/templates/empresas/cadastrar.html
+++ b/app/templates/empresas/cadastrar.html
@@ -12,20 +12,6 @@
         </div>
         
         <div class="card-body p-4">
-            {% with messages = get_flashed_messages(with_categories=true) %}
-                {% if messages %}
-                    <div class="flash-messages-container mb-4"> {# Adiciona margem inferior #}
-                        {% for category, message in messages %}
-                            <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-                                <i class="bi bi-{{ 'exclamation-triangle-fill' if category == 'error' else 'check-circle-fill' }} me-2"></i>
-                                {{ message }}
-                                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
-                            </div>
-                        {% endfor %}
-                    </div>
-                {% endif %}
-            {% endwith %}
-
             <form method="POST" action="{{ url_for('cadastrar_empresa') }}" novalidate>
                 {{ form.hidden_tag() }}
 

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -14,18 +14,6 @@
         </div>
     </div>
 
-    {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-            {% for category, message in messages %}
-                <div class="alert alert-{{ 'success' if category == 'success' else 'danger' }} alert-dismissible fade show" role="alert">
-                    <i class="bi bi-{{ 'check-circle' if category == 'success' else 'exclamation-triangle' }} me-2"></i>
-                    {{ message }}
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
-                </div>
-            {% endfor %}
-        {% endif %}
-    {% endwith %}
-
     <div class="row mb-4 sticky-top" style="top: 10px; z-index: 1000;">
         <div class="col-12">
             <div class="card border-0 shadow-sm bg-light">

--- a/app/templates/empresas/editar_empresa.html
+++ b/app/templates/empresas/editar_empresa.html
@@ -17,19 +17,6 @@
         </div>
     </div>
 
-    <!-- Mensagens Flash -->
-    {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-            {% for category, message in messages %}
-                <div class="alert alert-{{ 'danger' if category in ['error', 'danger'] else category }} alert-dismissible fade show" role="alert">
-                    <i class="bi bi-{{ 'exclamation-triangle' if category in ['error', 'danger'] else 'check-circle' }} me-2"></i>
-                    {{ message }}
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
-                </div>
-            {% endfor %}
-        {% endif %}
-    {% endwith %}
-
     <!-- Dados da Empresa -->
     <div class="card shadow-lg mb-5" id="dados-empresa">
         <div class="card-header bg-primary text-white py-3">

--- a/app/templates/empresas/listar.html
+++ b/app/templates/empresas/listar.html
@@ -22,19 +22,6 @@
         </div>
     </div>
 
-    <!-- Mensagens Flash -->
-    {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-            {% for category, message in messages %}
-                <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-                    <i class="bi bi-{{ 'exclamation-triangle' if category == 'error' else 'check-circle' }} me-2"></i>
-                    {{ message }}
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
-                </div>
-            {% endfor %}
-        {% endif %}
-    {% endwith %}
-
     <!-- Barra de Pesquisa -->
     <form method="GET" class="d-flex mb-3">
         <input type="text" name="q" class="form-control me-2" style="max-width: 300px;" placeholder="Buscar empresa" value="{{ search or '' }}">

--- a/app/templates/list_users.html
+++ b/app/templates/list_users.html
@@ -28,19 +28,6 @@
         </div>
     </div>
 
-    <!-- Mensagens Flash -->
-    {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-            {% for category, message in messages %}
-                <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-                    <i class="bi bi-{{ 'exclamation-triangle' if category == 'error' else 'check-circle' }} me-2"></i>
-                    {{ message }}
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
-                </div>
-            {% endfor %}
-        {% endif %}
-    {% endwith %}
-
     <!-- Tabela de Usuários -->
     <div class="card shadow-sm">
         <div class="card-body p-0">


### PR DESCRIPTION
## Summary
- centralize flash messages in `base.html`
- remove page-level flash handling from templates to avoid duplicates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e3e654ac48330bba7ec7c91346527