### PR TITLE
Fix sidebar width on dashboard and reports

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -47,6 +47,7 @@
       /* Sidebar Principal */
       .sidebar {
         width: var(--sidebar-width);
+        flex: 0 0 var(--sidebar-width);
         background: var(--sidebar-bg);
         border-right: 1px solid var(--border-color);
         box-shadow: 2px 0 10px rgba(0, 0, 0, 0.08);

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -23,6 +23,7 @@
         --text-muted: #6c757d;
         --danger-color: #dc3545;
         --danger-hover: #c82333;
+        --sidebar-width: 250px;
       }
 
       body, html {
@@ -45,7 +46,7 @@
 
       /* Sidebar Principal */
       .sidebar {
-        width: 280px;
+        width: var(--sidebar-width);
         background: var(--sidebar-bg);
         border-right: 1px solid var(--border-color);
         box-shadow: 2px 0 10px rgba(0, 0, 0, 0.08);
@@ -238,7 +239,7 @@
         .sidebar {
           position: fixed;
           top: 0;
-          left: -280px;
+          left: calc(-1 * var(--sidebar-width));
           height: 100vh;
           z-index: 1040;
           transition: left 0.3s ease;


### PR DESCRIPTION
## Summary
- define `--sidebar-width` variable and apply it to the sidebar
- align mobile sidebar offset with the new variable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f5dd51a1c8330a53b03c31bfdf2e0

## Summary by Sourcery

Introduce a CSS variable for sidebar width and apply it consistently across desktop and mobile layouts

Enhancements:
- Introduce --sidebar-width CSS variable for sidebar sizing
- Apply --sidebar-width variable to both desktop sidebar width and mobile sidebar offset