### PR TITLE
Fix department update timezone handling

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,8 @@ from flask_migrate import Migrate
 from flask_wtf.csrf import CSRFProtect
 from flask_login import LoginManager
 from dotenv import load_dotenv
-from datetime import datetime
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 from markupsafe import Markup
 
 load_dotenv()
@@ -34,6 +35,14 @@ def load_user(user_id):
 @app.context_processor
 def inject_now():
     return {'now': datetime.now}
+
+@app.template_filter('format_datetime_br')
+def format_datetime_br(value, fmt='%d/%m/%Y às %H:%M'):
+    if not value:
+        return ''
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(ZoneInfo('America/Sao_Paulo')).strftime(fmt)
 
 @app.template_global()
 def render_badge_list(items, classes, icon, placeholder):

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -2,7 +2,7 @@ import json
 from sqlalchemy.types import TypeDecorator, String
 from app import db
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, timezone
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
 
@@ -91,7 +91,11 @@ class Departamento(db.Model):
     ponto_eletronico = db.Column(db.String(200))
     pagamento_funcionario = db.Column(db.String(200))
     particularidades_texto = db.Column(db.Text)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc)
+    )
     empresa = db.relationship('Empresa', backref=db.backref('departamentos', lazy=True))
 
     def __repr__(self):

--- a/app/templates/departamentos/cadastrar.html
+++ b/app/templates/departamentos/cadastrar.html
@@ -75,7 +75,7 @@
                     <div class="alert alert-info d-flex align-items-center" role="alert">
                         <i class="bi bi-clock me-2"></i>
                         <div>
-                            <strong>Última atualização:</strong> {{ departamento.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                            <strong>Última atualização:</strong> {{ departamento.updated_at|format_datetime_br }}
                         </div>
                     </div>
                 </div>

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -157,7 +157,7 @@
                     <div class="alert alert-info d-flex align-items-center" role="alert">
                         <i class="bi bi-clock me-2"></i>
                         <div>
-                            <strong>Última atualização:</strong> {{ departamento.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                            <strong>Última atualização:</strong> {{ departamento.updated_at|format_datetime_br }}
                         </div>
                     </div>
                 </div>

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -187,7 +187,7 @@
                     <div class="alert alert-info d-flex align-items-center" role="alert">
                         <i class="bi bi-clock me-2"></i>
                         <div>
-                            <strong>Última atualização:</strong> {{ departamento.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                            <strong>Última atualização:</strong> {{ departamento.updated_at|format_datetime_br }}
                         </div>
                     </div>
                 </div>

--- a/app/templates/departamentos/cadastrar_pessoal.html
+++ b/app/templates/departamentos/cadastrar_pessoal.html
@@ -111,7 +111,7 @@
                     <div class="alert alert-info d-flex align-items-center" role="alert">
                         <i class="bi bi-clock me-2"></i>
                         <div>
-                            <strong>Última atualização:</strong> {{ departamento.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                            <strong>Última atualização:</strong> {{ departamento.updated_at|format_datetime_br }}
                         </div>
                     </div>
                 </div>

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -132,7 +132,7 @@
                     <button type="submit" class="btn btn-dept-blue px-5"><i class="bi bi-check-lg me-2"></i>Salvar Departamento Fiscal</button>
                 </div>
             </form>
-            {% if fiscal and fiscal.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ fiscal.updated_at.strftime('%d/%m/%Y às %H:%M') }}</div></div></div>{% endif %}
+            {% if fiscal and fiscal.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ fiscal.updated_at|format_datetime_br }}</div></div></div>{% endif %}
         </div>
     </div>
 
@@ -227,7 +227,7 @@
                     <button type="submit" class="btn btn-dept-orange px-5"><i class="bi bi-check-lg me-2"></i>Salvar Departamento Contábil</button>
                 </div>
             </form>
-            {% if contabil and contabil.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ contabil.updated_at.strftime('%d/%m/%Y às %H:%M') }}</div></div></div>{% endif %}
+            {% if contabil and contabil.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ contabil.updated_at|format_datetime_br }}</div></div></div>{% endif %}
         </div>
     </div>
 
@@ -301,7 +301,7 @@
                 <div class="alert alert-secondary d-flex align-items-center" role="alert">
                     <i class="bi bi-clock me-2"></i>
                     <div>
-                        <strong>Última atualização:</strong> {{ pessoal.updated_at.strftime('%d/%m/%Y às %H:%M') }}
+                        <strong>Última atualização:</strong> {{ pessoal.updated_at|format_datetime_br }}
                     </div>
                 </div>
             </div>
@@ -320,7 +320,7 @@
                     <button type="submit" class="btn btn-dept-orange px-5"><i class="bi bi-check-lg me-2"></i>Salvar Departamento Administrativo</button>
                 </div>
             </form>
-            {% if administrativo and administrativo.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ administrativo.updated_at.strftime('%d/%m/%Y às %H:%M') }}</div></div></div>{% endif %}
+            {% if administrativo and administrativo.updated_at %}<div class="mt-3"><div class="alert alert-secondary d-flex align-items-center" role="alert"><i class="bi bi-clock me-2"></i><div><strong>Última atualização:</strong> {{ administrativo.updated_at|format_datetime_br }}</div></div></div>{% endif %}
         </div>
     </div>
 

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -154,7 +154,7 @@
             <div class="card-header bg-dept-blue text-white py-3">
                 <div class="d-flex justify-content-between align-items-center">
                     <h3 class="mb-0 fw-semibold"><i class="bi bi-receipt me-2"></i>Departamento Fiscal</h3>
-                    {% if fiscal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ fiscal.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
+                    {% if fiscal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ fiscal.updated_at|format_datetime_br }}</small>{% endif %}
                 </div>
             </div>
             <div class="card-body p-4">
@@ -288,7 +288,7 @@
             <div class="card-header bg-dept-orange text-white py-3">
                 <div class="d-flex justify-content-between align-items-center">
                     <h3 class="mb-0 fw-semibold"><i class="bi bi-calculator me-2"></i>Departamento Contábil</h3>
-                    {% if contabil.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ contabil.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
+                    {% if contabil.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ contabil.updated_at|format_datetime_br }}</small>{% endif %}
                 </div>
             </div>
             <div class="card-body p-4">
@@ -380,7 +380,7 @@
                 <div class="card-header bg-dept-blue text-white py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <h3 class="mb-0 fw-semibold"><i class="bi bi-people me-2"></i>Departamento Pessoal</h3>
-                        {% if pessoal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ pessoal.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
+                        {% if pessoal.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ pessoal.updated_at|format_datetime_br }}</small>{% endif %}
                     </div>
                 </div>
                 <div class="card-body p-4">
@@ -459,7 +459,7 @@
             <div class="card-header bg-dept-orange text-white py-3">
                  <div class="d-flex justify-content-between align-items-center">
                     <h3 class="mb-0 fw-semibold"><i class="bi bi-gear me-2"></i>Departamento Administrativo</h3>
-                    {% if administrativo.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ administrativo.updated_at.strftime('%d/%m/%Y às %H:%M') }}</small>{% endif %}
+                    {% if administrativo.updated_at %}<small class="opacity-75"><i class="bi bi-clock me-1"></i>Atualizado: {{ administrativo.updated_at|format_datetime_br }}</small>{% endif %}
                 </div>
             </div>
             <div class="card-body p-4">


### PR DESCRIPTION
## Summary
- store Departamento.updated_at in UTC with timezone awareness
- add Jinja filter to convert timestamps to America/Sao_Paulo
- render department update times using new filter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f6c4ee1bc8330bb0425a9a1442b19

## Summary by Sourcery

Make department update timestamps timezone-aware by storing them in UTC and rendering them in Brazil/Sao_Paulo timezone using a new Jinja2 filter

New Features:
- Add Jinja2 filter to convert and format timestamps to America/Sao_Paulo timezone

Enhancements:
- Store Departamento.updated_at as a timezone-aware UTC timestamp
- Replace direct strftime calls in templates with the new format_datetime_br filter for consistent timezone handling