### PR TITLE
fix: improve auth and dashboard

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -1,6 +1,6 @@
-from flask import render_template, redirect, url_for, flash, request, abort, jsonify, current_app, Flask
+from flask import render_template, redirect, url_for, flash, request, abort, jsonify, current_app
 from functools import wraps
-from flask_login import current_user, login_required, login_user, logout_user, current_user
+from flask_login import current_user, login_required, login_user, logout_user
 from app import app, db
 from app.loginForms import LoginForm, RegistrationForm
 from app.models.tables import User, Empresa, Departamento
@@ -602,7 +602,6 @@ def gerenciar_departamentos(empresa_id):
     )
 
 @app.route('/relatorios')
-@login_required
 @admin_required
 def relatorios():
     return render_template('admin/relatorios.html')
@@ -625,7 +624,6 @@ def test_connection():
     ## Rota para listar usuários
 
 @app.route('/users', methods=['GET', 'POST'])
-@login_required
 @admin_required
 def list_users():
     form = RegistrationForm()
@@ -657,7 +655,6 @@ def list_users():
     return render_template('list_users.html', users=users, form=form, show_inactive=show_inactive)
 
 @app.route('/novo_usuario', methods=['GET', 'POST'])
-@login_required
 @admin_required
 def novo_usuario():
     form = RegistrationForm()
@@ -682,7 +679,6 @@ def novo_usuario():
     return render_template('admin/novo_usuario.html', form=form)
 
 @app.route('/user/edit/<int:user_id>', methods=['GET', 'POST'])
-@login_required
 @admin_required
 def edit_user(user_id):
     user = User.query.get_or_404(user_id)

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -41,6 +41,11 @@ class User(db.Model, UserMixin):
     def check_password(self, password):
         return check_password_hash(self.password, password)
 
+    @property
+    def is_active(self):
+        """Return True if the user is marked as active."""
+        return self.ativo
+
 class Post(db.Model):
     __tablename__ = "posts"
     id = db.Column(db.Integer, primary_key=True)

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -19,6 +19,28 @@
         </div>
     </div>
 
+    <!-- Statistics -->
+    <div class="row mb-4">
+        <div class="col-md-6 col-lg-3 mb-3 mb-lg-0">
+            <div class="card text-center border-0 shadow-sm">
+                <div class="card-body">
+                    <h2 class="mb-0">{{ total_empresas }}</h2>
+                    <p class="text-muted mb-0">Empresas</p>
+                </div>
+            </div>
+        </div>
+        {% if current_user.role == 'admin' %}
+        <div class="col-md-6 col-lg-3">
+            <div class="card text-center border-0 shadow-sm">
+                <div class="card-body">
+                    <h2 class="mb-0">{{ total_usuarios }}</h2>
+                    <p class="text-muted mb-0">Usuários</p>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+
     <!-- Ações Principais -->
     <div class="row mb-5">
         {% set actions = [


### PR DESCRIPTION
## Summary
- enforce active user flag via is_active property
- simplify admin routes to rely solely on role-based decorator
- show basic stats on dashboard

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a32c7b0dd0833080b63870390b1dd0

## Summary by Sourcery

Enforce user active status via a new model property, streamline admin route protection to use only role-based checks, and introduce basic statistics to the dashboard.

New Features:
- Display total companies and, for admins, total users statistics on the dashboard

Enhancements:
- Add is_active property to User model to enforce active user flag
- Simplify admin routes by removing redundant login_required decorator and relying solely on admin_required