### PR TITLE
feat: enrich company data by CNPJ

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -13,6 +13,7 @@ from app.forms import (
     DepartamentoPessoalForm,
 )
 import os, json, re
+from app.services.cnpj import consultar_cnpj
 from werkzeug.utils import secure_filename
 from uuid import uuid4
 from sqlalchemy import or_
@@ -169,6 +170,15 @@ def login():
 @login_required
 def dashboard():
     return render_template('dashboard.html')
+
+
+@app.route('/api/cnpj/<cnpj>')
+@login_required
+def api_consultar_cnpj(cnpj):
+    data = consultar_cnpj(cnpj)
+    if not data or not data.get('externo'):
+        return jsonify({'error': 'CNPJ não encontrado'}), 404
+    return jsonify(data)
 
     ## Rota para cadastrar uma nova empresa
 

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+# Utility services package for external integrations

--- a/app/services/cnpj.py
+++ b/app/services/cnpj.py
@@ -1,0 +1,113 @@
+import os
+import re
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import requests
+
+TOKEN_ACESSORIAS = os.getenv("TOKEN_ACESSORIAS", "")
+BASE_ACESSORIAS = "https://api.acessorias.com"
+ENVIAR_PARA_ACESSORIAS = os.getenv("ENVIAR_PARA_ACESSORIAS") == "True"
+
+
+def somente_numeros(s: str) -> str:
+    """Remove todos os caracteres não numéricos."""
+    return re.sub(r"\D", "", s or "")
+
+def ymd(d: str) -> Optional[str]:
+    """Converte datas diversas para o formato YYYY-MM-DD."""
+    if not d:
+        return None
+    for fmt in ("%Y-%m-%d", "%d/%m/%Y", "%Y%m%d"):
+        try:
+            return datetime.strptime(d, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+    return None
+
+
+def get_acessorias_company(cnpj: str) -> Optional[Dict[str, Any]]:
+    """Consulta no Acessórias dados já cadastrados."""
+    if not TOKEN_ACESSORIAS:
+        return None
+    url = f"{BASE_ACESSORIAS}/companies/{cnpj}"
+    headers = {"Authorization": f"Bearer {TOKEN_ACESSORIAS}", "Accept": "application/json"}
+    r = requests.get(url, headers=headers, timeout=20)
+    if r.status_code == 200:
+        try:
+            return r.json()
+        except Exception:
+            return {"raw": r.text}
+    if r.status_code == 404:
+        return None
+    return None
+
+
+def get_brasilapi_cnpj(cnpj: str) -> Optional[Dict[str, Any]]:
+    url = f"https://brasilapi.com.br/api/cnpj/v1/{cnpj}"
+    r = requests.get(url, timeout=20)
+    if r.status_code == 200:
+        return r.json()
+    return None
+
+
+def get_receitaws_cnpj(cnpj: str) -> Optional[Dict[str, Any]]:
+    url = f"https://www.receitaws.com.br/v1/cnpj/{cnpj}"
+    r = requests.get(url, timeout=20)
+    if r.status_code == 200:
+        try:
+            data = r.json()
+            if data.get("status") == "ERROR":
+                return None
+            return data
+        except Exception:
+            return None
+    return None
+
+
+def mapear_para_acessorias(d: Dict[str, Any]) -> Dict[str, Any]:
+    """Mapeia campos externos para o payload do Acessórias."""
+    payload = {
+        "cnpj": somente_numeros(d.get("cnpj") or d.get("identificador") or ""),
+        "nome": d.get("razao_social") or d.get("nome") or d.get("razao") or "",
+        "fantasia": d.get("nome_fantasia") or d.get("fantasia") or "",
+        "dtabertura": ymd(d.get("data_inicio_atividade") or d.get("abertura")),
+        "endlogradouro": (d.get("logradouro") or d.get("descricao_tipo_de_logradouro") or "")
+                         + ((" " + d.get("titulo_do_logradouro")) if d.get("titulo_do_logradouro") else ""),
+        "endnumero": d.get("numero") or "",
+        "endcomplemento": d.get("complemento") or "",
+        "bairro": d.get("bairro") or "",
+        "cep": somente_numeros(d.get("cep") or ""),
+        "cidade": d.get("municipio") or d.get("cidade") or "",
+        "uf": d.get("uf") or d.get("estado") or "",
+        "fone": d.get("telefone") or "",
+        "ativa": "S" if (d.get("situacao_cadastral") in (2, "ATIVA", "Ativa")) else "N",
+    }
+    payload = {k: v for k, v in payload.items() if v not in ("", None)}
+    return payload
+
+
+def upsert_acessorias_company(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not TOKEN_ACESSORIAS:
+        return None
+    url = f"{BASE_ACESSORIAS}/companies"
+    headers = {"Authorization": f"Bearer {TOKEN_ACESSORIAS}", "Accept": "application/json"}
+    r = requests.post(url, headers=headers, json=payload, timeout=30)
+    try:
+        data = r.json()
+    except Exception:
+        data = {"status_code": r.status_code, "raw": r.text}
+    return data
+
+
+def consultar_cnpj(cnpj_input: str) -> Optional[Dict[str, Any]]:
+    """Orquestra a consulta no Acessórias e fontes externas."""
+    cnpj = somente_numeros(cnpj_input)
+    base = get_acessorias_company(cnpj)
+    externos = get_brasilapi_cnpj(cnpj) or get_receitaws_cnpj(cnpj)
+    if not externos:
+        return {"acessorias": base}
+    payload = mapear_para_acessorias(externos)
+    if ENVIAR_PARA_ACESSORIAS:
+        upsert_acessorias_company(payload)
+    return {"acessorias": base, "externo": externos, "payload": payload}

--- a/app/templates/empresas/cadastrar.html
+++ b/app/templates/empresas/cadastrar.html
@@ -271,6 +271,34 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Máscara para CNPJ
     const cnpjField = document.querySelector('#cnpj');
+
+    async function fetchCNPJData(cnpj) {
+        try {
+            const resp = await fetch(`/api/cnpj/${cnpj}`);
+            if (!resp.ok) return;
+            const data = await resp.json();
+            const payload = data.payload || {};
+            const externo = data.externo || {};
+            const nomeField = document.querySelector('#nome_empresa');
+            const aberturaField = document.querySelector('#data_abertura');
+            const atividadeField = document.querySelector('#atividade_principal');
+            if (payload.nome && nomeField && !nomeField.value) {
+                nomeField.value = payload.nome;
+                validateField(nomeField);
+            }
+            if (payload.dtabertura && aberturaField && !aberturaField.value) {
+                aberturaField.value = payload.dtabertura;
+                validateField(aberturaField);
+            }
+            if (externo.cnae_fiscal_descricao && atividadeField && !atividadeField.value) {
+                atividadeField.value = externo.cnae_fiscal_descricao;
+                validateField(atividadeField);
+            }
+        } catch (err) {
+            console.error(err);
+        }
+    }
+
     if (cnpjField) {
         cnpjField.addEventListener('input', function(e) {
             let value = e.target.value.replace(/\D/g, ''); // Remove tudo que não é dígito
@@ -287,6 +315,13 @@ document.addEventListener("DOMContentLoaded", function () {
         });
 
         // Pre-fill CNPJ with mask if data exists (for edit scenarios)
+        cnpjField.addEventListener('blur', function() {
+            const clean = cnpjField.value.replace(/\D/g, '');
+            if (clean.length === 14) {
+                fetchCNPJData(clean);
+            }
+        });
+
         if (cnpjField.value) {
             let initialValue = cnpjField.value.replace(/\D/g, '');
             initialValue = initialValue.replace(/^(\d{2})(\d)/, '$1.$2');

--- a/app/templates/empresas/editar_empresa.html
+++ b/app/templates/empresas/editar_empresa.html
@@ -251,9 +251,40 @@
 document.addEventListener("DOMContentLoaded", function () {
     // Máscara para CNPJ
     const cnpjField = document.querySelector('#cnpj');
+
+    async function fetchCNPJData(cnpj) {
+        try {
+            const resp = await fetch(`/api/cnpj/${cnpj}`);
+            if (!resp.ok) return;
+            const data = await resp.json();
+            const payload = data.payload || {};
+            const externo = data.externo || {};
+            const nomeField = document.querySelector('#nome_empresa');
+            const aberturaField = document.querySelector('#data_abertura');
+            const atividadeField = document.querySelector('#atividade_principal');
+            if (payload.nome && nomeField && !nomeField.value) {
+                nomeField.value = payload.nome;
+            }
+            if (payload.dtabertura && aberturaField && !aberturaField.value) {
+                aberturaField.value = payload.dtabertura;
+            }
+            if (externo.cnae_fiscal_descricao && atividadeField && !atividadeField.value) {
+                atividadeField.value = externo.cnae_fiscal_descricao;
+            }
+        } catch (err) {
+            console.error(err);
+        }
+    }
+
     if (cnpjField) {
         IMask(cnpjField, {
             mask: '00.000.000/0000-00'
+        });
+        cnpjField.addEventListener('blur', function() {
+            const clean = cnpjField.value.replace(/\D/g, '');
+            if (clean.length === 14) {
+                fetchCNPJData(clean);
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- add service to consult and map CNPJ data from BrasilAPI/ReceitaWS and Acessórias
- expose `/api/cnpj/<cnpj>` endpoint
- auto-fill company forms with fetched data

## Testing
- `python -m py_compile app/services/cnpj.py app/controllers/routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a35d9610748330952aa37668e2dd66

## Summary by Sourcery

Add CNPJ-based company data enrichment by introducing a new service to fetch and map data from BrasilAPI, ReceitaWS, and Acessórias, exposing a secured `/api/cnpj/<cnpj>` endpoint, and auto-populating company registration and edit forms with the retrieved data.

New Features:
- Implement CNPJ service to query and unify external company data sources
- Add `/api/cnpj/<cnpj>` API route to return enriched CNPJ data
- Auto-fill company form fields on the client side based on fetched CNPJ information

Chores:
- Initialize services package with `app/services/__init__.py`