### PR TITLE
Add fiscal importation pie chart report

### DIFF
--- a/app/templates/admin/relatorio_fiscal_importacoes.html
+++ b/app/templates/admin/relatorio_fiscal_importacoes.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Relatório Fiscal - Importações{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <h1 class="text-primary mb-4"><i class="bi bi-pie-chart me-2"></i>Importações - Departamento Fiscal</h1>
+    <div id="import-chart"></div>
+    <div id="selected-count" class="mt-3 text-center fw-bold"></div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<script>
+    var graphs = {{ graphJSON | safe }};
+    var chartDiv = document.getElementById('import-chart');
+    Plotly.newPlot(chartDiv, graphs.data, graphs.layout);
+    chartDiv.on('plotly_click', function(data){
+        var label = data.points[0].label;
+        var value = data.points[0].value;
+        document.getElementById('selected-count').innerHTML = label + ': ' + value + ' empresas';
+    });
+</script>
+{% endblock %}

--- a/app/templates/admin/relatorios.html
+++ b/app/templates/admin/relatorios.html
@@ -72,10 +72,10 @@
                         Análise detalhada dos dados fiscais, obrigações tributárias e configurações de envio digital das empresas.
                     </p>
                     <div class="mb-3">
-                        <span class="badge bg-warning-subtle text-warning">
-                            <i class="bi bi-clock me-1"></i>Em desenvolvimento
-                        </span>
-                    </div>
+        <span class="badge bg-primary-subtle text-primary">
+            <i class="bi bi-check-circle me-1"></i>Disponível
+        </span>
+    </div>
                     <ul class="list-unstyled small text-muted mb-3">
                         <li><i class="bi bi-hourglass me-2 text-warning"></i>Obrigações fiscais por empresa</li>
                         <li><i class="bi bi-hourglass me-2 text-warning"></i>Cronograma de entregas</li>
@@ -83,9 +83,9 @@
                     </ul>
                 </div>
                 <div class="card-footer bg-transparent border-0">
-                    <button class="btn btn-success w-100 disabled" disabled>
-                        <i class="bi bi-tools me-2"></i>Em Breve
-                    </button>
+                    <a href="{{ url_for('relatorio_fiscal_importacoes') }}" class="btn btn-success w-100">
+                        <i class="bi bi-arrow-right-circle me-2"></i>Acessar Relatório
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Add Plotly-based pie chart for fiscal department import methods
- Expose fiscal report link in admin page
- Create template for interactive importation chart

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a488cb3c088330aa38d5b18eb4db5b