### PR TITLE
Add donut chart user role report

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -15,8 +15,9 @@ from app.forms import (
 import os, json, re
 from werkzeug.utils import secure_filename
 from uuid import uuid4
-from sqlalchemy import or_
+from sqlalchemy import or_, func
 from app.services.cnpj import consultar_cnpj
+import plotly.graph_objects as go
 
 @app.context_processor
 def inject_stats():
@@ -623,6 +624,18 @@ def gerenciar_departamentos(empresa_id):
 @admin_required
 def relatorios():
     return render_template('admin/relatorios.html')
+
+
+@app.route('/relatorio_usuarios')
+@admin_required
+def relatorio_usuarios():
+    data = db.session.query(User.role, func.count(User.id)).group_by(User.role).all()
+    roles = [r for r, _ in data]
+    counts = [c for _, c in data]
+    fig = go.Figure(data=[go.Pie(labels=roles, values=counts, hole=0.4)])
+    fig.update_layout(title_text='Usuários por tipo')
+    chart_div = fig.to_html(full_html=False)
+    return render_template('admin/relatorio_usuarios.html', chart_div=chart_div)
 
 @app.route('/logout', methods=['GET'])
 @login_required

--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -629,11 +629,21 @@ def relatorios():
 @app.route('/relatorio_usuarios')
 @admin_required
 def relatorio_usuarios():
-    data = db.session.query(User.role, func.count(User.id)).group_by(User.role).all()
-    roles = [r for r, _ in data]
-    counts = [c for _, c in data]
-    fig = go.Figure(data=[go.Pie(labels=roles, values=counts, hole=0.4)])
-    fig.update_layout(title_text='Usuários por tipo')
+    data = (
+        db.session
+        .query(User.role, User.ativo, func.count(User.id))
+        .group_by(User.role, User.ativo)
+        .all()
+    )
+    labels = []
+    counts = []
+    for role, ativo, count in data:
+        tipo = 'Admin' if role == 'admin' else 'Usuário'
+        status = 'Ativo' if ativo else 'Inativo'
+        labels.append(f'{tipo} {status}')
+        counts.append(count)
+    fig = go.Figure(data=[go.Pie(labels=labels, values=counts, hole=0.4)])
+    fig.update_layout(title_text='Usuários por tipo e status')
     chart_div = fig.to_html(full_html=False)
     return render_template('admin/relatorio_usuarios.html', chart_div=chart_div)
 

--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -629,18 +629,22 @@ def relatorios():
 @app.route('/relatorio_usuarios')
 @admin_required
 def relatorio_usuarios():
-    users = User.query.with_entities(User.username, User.role, User.ativo).all()
+    users = User.query.with_entities(
+        User.username, User.name, User.email, User.role, User.ativo
+    ).all()
     grouped = {}
     labels = []
     counts = []
-    for username, role, ativo in users:
+    for username, name, email, role, ativo in users:
         tipo = 'Admin' if role == 'admin' else 'Usuário'
         status = 'Ativo' if ativo else 'Inativo'
         label = f'{tipo} {status}'
-        grouped.setdefault(label, []).append(username)
-    for label, nomes in grouped.items():
+        grouped.setdefault(label, []).append(
+            {"username": username, "name": name, "email": email}
+        )
+    for label, usuarios in grouped.items():
         labels.append(label)
-        counts.append(len(nomes))
+        counts.append(len(usuarios))
     fig = go.Figure(data=[go.Pie(labels=labels, values=counts, hole=0.4)])
     fig.update_layout(title_text='Usuários por tipo e status')
     chart_div = fig.to_html(full_html=False, div_id='user-role-chart')

--- a/app/templates/admin/relatorio_usuarios.html
+++ b/app/templates/admin/relatorio_usuarios.html
@@ -8,7 +8,7 @@
     <div id="chart-container">
         {{ chart_div|safe }}
     </div>
-    <div id="user-list" class="mt-4"></div>
+    <div id="user-list" class="mt-4 d-flex justify-content-center"></div>
 </div>
 <script>
     const usersBySlice = {{ users_by_slice|tojson }};
@@ -19,12 +19,12 @@
             const users = usersBySlice[label] || [];
             const container = document.getElementById('user-list');
             if (!users.length) {
-                container.innerHTML = '<p>Nenhum usuário encontrado.</p>';
+                container.innerHTML = '<p class="text-center">Nenhum usuário encontrado.</p>';
                 return;
             }
-            let html = '<ul>';
-            users.forEach(name => { html += `<li>${name}</li>`; });
-            html += '</ul>';
+            let html = '<div class="table-responsive"><table class="table table-striped w-auto text-start"><thead><tr><th>Nome</th><th>Email</th><th>Usuário</th></tr></thead><tbody>';
+            users.forEach(u => { html += `<tr><td>${u.name}</td><td>${u.email}</td><td>${u.username}</td></tr>`; });
+            html += '</tbody></table></div>';
             container.innerHTML = html;
         });
     }

--- a/app/templates/admin/relatorio_usuarios.html
+++ b/app/templates/admin/relatorio_usuarios.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="container mt-4">
-    <h1 class="mb-4">Usuários por Tipo</h1>
+    <h1 class="mb-4">Usuários por Tipo e Status</h1>
     <div>
         {{ chart_div|safe }}
     </div>

--- a/app/templates/admin/relatorio_usuarios.html
+++ b/app/templates/admin/relatorio_usuarios.html
@@ -5,8 +5,28 @@
 {% block content %}
 <div class="container mt-4">
     <h1 class="mb-4">Usuários por Tipo e Status</h1>
-    <div>
+    <div id="chart-container">
         {{ chart_div|safe }}
     </div>
+    <div id="user-list" class="mt-4"></div>
 </div>
+<script>
+    const usersBySlice = {{ users_by_slice|tojson }};
+    const chart = document.getElementById('user-role-chart');
+    if (chart) {
+        chart.on('plotly_click', function(data){
+            const label = data.points[0].label;
+            const users = usersBySlice[label] || [];
+            const container = document.getElementById('user-list');
+            if (!users.length) {
+                container.innerHTML = '<p>Nenhum usuário encontrado.</p>';
+                return;
+            }
+            let html = '<ul>';
+            users.forEach(name => { html += `<li>${name}</li>`; });
+            html += '</ul>';
+            container.innerHTML = html;
+        });
+    }
+</script>
 {% endblock %}

--- a/app/templates/admin/relatorio_usuarios.html
+++ b/app/templates/admin/relatorio_usuarios.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}Relatório de Usuários{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h1 class="mb-4">Usuários por Tipo</h1>
+    <div>
+        {{ chart_div|safe }}
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/admin/relatorios.html
+++ b/app/templates/admin/relatorios.html
@@ -179,7 +179,7 @@
                     </ul>
                 </div>
                 <div class="card-footer bg-transparent border-0">
-                    <a href="{{ url_for('list_users') }}" class="btn btn-dark w-100">
+                    <a href="{{ url_for('relatorio_usuarios') }}" class="btn btn-dark w-100">
                         <i class="bi bi-arrow-right-circle me-2"></i>Acessar Relatório
                     </a>
                 </div>

--- a/app/templates/admin/relatorios.html
+++ b/app/templates/admin/relatorios.html
@@ -173,7 +173,7 @@
                         </span>
                     </div>
                     <ul class="list-unstyled small text-muted mb-3">
-                        <li><i class="bi bi-check2 me-2 text-success"></i>Lista de usuários ativos</li>
+                        <li><i class="bi bi-check2 me-2 text-success"></i>Lista de usuários ativos e inativos</li>
                         <li><i class="bi bi-check2 me-2 text-success"></i>Perfis e permissões</li>
                         <li><i class="bi bi-check2 me-2 text-success"></i>Histórico de acessos</li>
                     </ul>


### PR DESCRIPTION
## Summary
- add `relatorio_usuarios` route that displays user counts by role in a Plotly donut chart
- include new `relatorio_usuarios` template
- link report from the admin reports page

## Testing
- `python -m py_compile app/controllers/routes.py`


------
https://chatgpt.com/codex/tasks/task_b_68a48bd040988330a5a9a342fff26449

## Summary by Sourcery

Add an admin user role report endpoint rendering a Plotly donut chart of user counts by role

New Features:
- Provide /relatorio_usuarios route to query user roles and render a donut chart
- Add a dedicated template to display the user role report
- Update the admin reports page to link to the new user role report