### PR TITLE
Add sorting filters for company list

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -240,9 +240,22 @@ def listar_empresas():
             )
         )
 
+    sort = request.args.get('sort', 'nome')
+    order = request.args.get('order', 'asc')
+
+    if sort == 'codigo':
+        order_column = Empresa.codigo_empresa
+    else:
+        order_column = Empresa.nome_empresa
+
+    if order == 'desc':
+        query = query.order_by(order_column.desc())
+    else:
+        query = query.order_by(order_column.asc())
+
     empresas = query.all()
 
-    return render_template('empresas/listar.html', empresas=empresas, search=search)
+    return render_template('empresas/listar.html', empresas=empresas, search=search, sort=sort, order=order)
 
 def processar_dados_fiscal(request):
     """Função auxiliar para processar dados do departamento fiscal"""

--- a/app/templates/empresas/listar.html
+++ b/app/templates/empresas/listar.html
@@ -25,6 +25,8 @@
     <!-- Barra de Pesquisa -->
     <form method="GET" class="d-flex mb-3">
         <input type="text" name="q" class="form-control me-2" style="max-width: 300px;" placeholder="Buscar empresa" value="{{ search or '' }}">
+        <input type="hidden" name="sort" value="{{ sort }}">
+        <input type="hidden" name="order" value="{{ order }}">
         <button class="btn btn-outline-secondary" type="submit">
             <i class="bi bi-search"></i>
         </button>
@@ -37,8 +39,24 @@
                 <table class="table-empresas">
                     <thead>
                         <tr>
-                            <th class="codigo-col">Código</th>
-                            <th>Nome da Empresa</th>
+                            <th class="codigo-col">
+                                Código
+                                <a href="{{ url_for('listar_empresas', q=search, sort='codigo', order='asc') }}" class="text-white ms-1" title="Código crescente">
+                                    <i class="bi bi-sort-numeric-down"></i>
+                                </a>
+                                <a href="{{ url_for('listar_empresas', q=search, sort='codigo', order='desc') }}" class="text-white" title="Código decrescente">
+                                    <i class="bi bi-sort-numeric-up"></i>
+                                </a>
+                            </th>
+                            <th>
+                                Nome da Empresa
+                                <a href="{{ url_for('listar_empresas', q=search, sort='nome', order='asc') }}" class="text-white ms-1" title="Nome A-Z">
+                                    <i class="bi bi-sort-alpha-down"></i>
+                                </a>
+                                <a href="{{ url_for('listar_empresas', q=search, sort='nome', order='desc') }}" class="text-white" title="Nome Z-A">
+                                    <i class="bi bi-sort-alpha-up"></i>
+                                </a>
+                            </th>
                             <th class="cnpj-col">CNPJ</th>
                             <th class="tributacao-col">Tributação</th>
                             <th class="acao-col">Ações</th>


### PR DESCRIPTION
## Summary
- allow sorting companies by code or name in the listing route
- add table header controls to filter companies alphabetically or by code

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a4c391708c8330839d5f4bd0becd4c