### PR TITLE
Add Web Service import option for Fiscal department

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -97,6 +97,7 @@ class DepartamentoFiscalForm(DepartamentoForm):
     formas_importacao = SelectMultipleField('Formas de Importação', choices=[
         ('entradas_sped', 'Entradas por Sped'), ('entradas_xml', 'Entradas por XML'),
         ('entradas_sat', 'Entradas pelo SAT'), ('entradas_sieg', 'Entradas pelo Sieg'),
+        ('entradas_webservice', 'Entradas pelo Web Service'),
         ('saidas_sped', 'Saídas por Sped'), ('saidas_xml', 'Saídas por XML'),
         ('saidas_sieg', 'Saídas pelo SIEG'), ('nfce_sped', 'NFCe por Sped'),
         ('nfce_xml_sieg', 'NFCe por XML - Sieg'), ('nfce_xml_cliente', 'NFCe por XML - Copiado do cliente'),

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -256,6 +256,7 @@
                                     'entradas_xml': 'Entradas por XML',
                                     'entradas_sat': 'Entradas pelo SAT',
                                     'entradas_sieg': 'Entradas pelo Sieg',
+                                    'entradas_webservice': 'Entradas pelo Web Service',
                                     'saidas_sped': 'Saídas por Sped',
                                     'saidas_xml': 'Saídas por XML',
                                     'saidas_sieg': 'Saídas pelo SIEG',


### PR DESCRIPTION
## Summary
- add "Entradas pelo Web Service" option for fiscal import methods
- display new option in company fiscal info view

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4d7e53eac8330b1adcf2bae906bae

## Summary by Sourcery

Add Web Service as a new import method for the fiscal department and display it in the company fiscal info view.

New Features:
- Introduce "Entradas pelo Web Service" option in fiscal import methods dropdown
- Include the new Web Service option in the company fiscal info display template