### PR TITLE
Refine user report formatting and chart style

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -18,6 +18,7 @@ from uuid import uuid4
 from sqlalchemy import or_
 from app.services.cnpj import consultar_cnpj
 import plotly.graph_objects as go
+from plotly.colors import qualitative
 
 @app.context_processor
 def inject_stats():
@@ -678,8 +679,22 @@ def relatorio_usuarios():
     for label, usuarios in grouped.items():
         labels.append(label)
         counts.append(len(usuarios))
-    fig = go.Figure(data=[go.Pie(labels=labels, values=counts, hole=0.4)])
-    fig.update_layout(title_text='Usuários por tipo e status')
+    fig = go.Figure(
+        data=[
+            go.Pie(
+                labels=labels,
+                values=counts,
+                hole=0.4,
+                marker=dict(colors=qualitative.Pastel, line=dict(color="#FFFFFF", width=2)),
+                textinfo="label+percent",
+            )
+        ]
+    )
+    fig.update_layout(
+        title_text="Usuários por tipo e status",
+        template="seaborn",
+        legend=dict(orientation="h", y=-0.1, x=0.5, xanchor="center"),
+    )
     chart_div = fig.to_html(full_html=False, div_id='user-role-chart')
     return render_template(
         'admin/relatorio_usuarios.html',

--- a/app/templates/admin/relatorio_usuarios.html
+++ b/app/templates/admin/relatorio_usuarios.html
@@ -23,7 +23,12 @@
                 return;
             }
             let html = '<div class="table-responsive"><table class="table table-striped w-auto text-start"><thead><tr><th>Nome</th><th>Email</th><th>Usuário</th></tr></thead><tbody>';
-            users.forEach(u => { html += `<tr><td>${u.name}</td><td>${u.email}</td><td>${u.username}</td></tr>`; });
+            users.forEach(u => {
+                const name = u.name ? u.name.toUpperCase() : '';
+                const email = u.email ? u.email.toLowerCase() : '';
+                const username = u.username ? u.username.toLowerCase() : '';
+                html += `<tr><td>${name}</td><td>${email}</td><td>${username}</td></tr>`;
+            });
             html += '</tbody></table></div>';
             container.innerHTML = html;
         });


### PR DESCRIPTION
## Summary
- Display user names in uppercase and emails and usernames in lowercase within the user report table
- Improve user report pie chart with pastel colors, labels, and horizontal legend for better readability

## Testing
- `python -m py_compile app/controllers/routes.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a5d179d2448330aa9a539d6a3e32e6

## Summary by Sourcery

Refine the user report table to normalize casing and enhance the pie chart’s visual style for improved readability

Enhancements:
- Display user names in uppercase and emails and usernames in lowercase in the report table
- Apply pastel color palette, white slice borders, label+percent text, seaborn template, and a horizontal legend to the pie chart