### PR TITLE
Allow multiple import methods for accounting department

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -314,7 +314,7 @@ def processar_dados_contabil(request):
     """Função auxiliar para processar dados do departamento contábil"""
     responsavel = request.form.get('responsavel')
     descricao = request.form.get('descricao')
-    metodo_importacao = request.form.get('metodo_importacao')
+    metodo_importacao = request.form.getlist('metodo_importacao')
     forma_movimento = request.form.get('forma_movimento')
     particularidades = request.form.get('particularidades')
     envio_digital = request.form.getlist('envio_digital')
@@ -536,6 +536,10 @@ def gerenciar_departamentos(empresa_id):
 
         contabil_form = DepartamentoContabilForm(obj=contabil)
         if contabil:
+            contabil_form.metodo_importacao.data = (
+                contabil.metodo_importacao if isinstance(contabil.metodo_importacao, list)
+                else json.loads(contabil.metodo_importacao) if contabil.metodo_importacao else []
+            )
             contabil_form.envio_digital.data = (
                 contabil.envio_digital if isinstance(contabil.envio_digital, list)
                 else json.loads(contabil.envio_digital) if contabil.envio_digital else []
@@ -586,6 +590,7 @@ def gerenciar_departamentos(empresa_id):
             else:
                 contabil.malote_coleta = contabil_form.malote_coleta.data
 
+            contabil.metodo_importacao = contabil_form.metodo_importacao.data or []
             contabil.envio_digital = contabil_form.envio_digital.data or []
             contabil.envio_fisico = contabil_form.envio_fisico.data or []
             contabil.controle_relatorios = contabil_form.controle_relatorios.data or []

--- a/app/forms.py
+++ b/app/forms.py
@@ -125,8 +125,8 @@ class DepartamentoFiscalForm(DepartamentoForm):
 
 class DepartamentoContabilForm(DepartamentoForm):
     """Formulário para o Departamento Contábil."""
-    metodo_importacao = SelectField('Forma de Importação', choices=[
-        ('', 'Selecione'), ('importado', 'Importado'), ('digitado', 'Digitado')
+    metodo_importacao = SelectMultipleField('Formas de Importação', choices=[
+        ('importado', 'Importado'), ('digitado', 'Digitado')
     ], validators=[Optional()])
     forma_movimento = SelectField('Envio de Documento', choices=[
         ('', 'Selecione'), ('Digital', 'Digital'), ('Fisico', 'Físico'), ('Digital e Físico', 'Digital e Físico')

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -94,7 +94,7 @@ class Departamento(db.Model):
     observacao_importacao = db.Column(db.String(200))
     observacao_prefeitura = db.Column(db.String(200))
     observacao_contato = db.Column(db.String(200))
-    metodo_importacao = db.Column(db.String(20))
+    metodo_importacao = db.Column(JsonString(255))
     controle_relatorios = db.Column(JsonString(255))
     observacao_controle_relatorios = db.Column(db.String(200))
     contatos = db.Column(JsonString(255))

--- a/app/templates/departamentos/cadastrar_contabil.html
+++ b/app/templates/departamentos/cadastrar_contabil.html
@@ -26,7 +26,18 @@
                 <div class="row g-4 mb-4">
                     <div class="col-md-6">
                         <label class="form-label fw-semibold">{{ form.metodo_importacao.label.text }}</label>
-                        {{ form.metodo_importacao(class="form-select") }}
+                        <div class="border rounded p-3 bg-light">
+                            <div class="row">
+                                {% for value, label in form.metodo_importacao.choices %}
+                                <div class="col-md-6 mb-2">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="{{ form.metodo_importacao.name }}" value="{{ value }}" id="mi-{{ loop.index }}" {% if value in (form.metodo_importacao.data or []) %}checked{% endif %}>
+                                        <label class="form-check-label" for="mi-{{ loop.index }}">{{ label }}</label>
+                                    </div>
+                                </div>
+                                {% endfor %}
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -163,7 +163,19 @@
                 
                 <h5 class="text-dept-orange border-bottom pb-2 mb-3"><i class="bi bi-gear me-2"></i>Envio de Documento</h5>
                 <div class="row g-4 mb-4">
-                    <div class="col-md-6"><label class="form-label fw-semibold">{{ contabil_form.metodo_importacao.label.text }}</label>{{ contabil_form.metodo_importacao(class="form-select") }}</div>
+                    <div class="col-md-6">
+                        <label class="form-label fw-semibold">{{ contabil_form.metodo_importacao.label.text }}</label>
+                        <div class="border rounded p-3 bg-light"><div class="row">
+                            {% for value, label in contabil_form.metodo_importacao.choices %}
+                            <div class="col-md-6 mb-2">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" name="{{ contabil_form.metodo_importacao.name }}" value="{{ value }}" id="contabil-mi-{{ loop.index }}" {% if value in (contabil_form.metodo_importacao.data or []) %}checked{% endif %}>
+                                    <label class="form-check-label" for="contabil-mi-{{ loop.index }}">{{ label }}</label>
+                                </div>
+                            </div>
+                            {% endfor %}
+                        </div></div>
+                    </div>
                     <div class="col-md-6"><label class="form-label fw-semibold">{{ contabil_form.forma_movimento.label.text }}</label>{{ contabil_form.forma_movimento(id="contabil_forma_movimento", class="form-select") }}</div>
                 </div>
 

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -362,7 +362,19 @@
                             <h6 class="text-dept-orange mb-3 border-bottom pb-2"><i class="bi bi-info-circle me-2"></i>Informações Básicas</h6>
                             <div class="info-item">
                                 <label class="info-label">Método de Importação</label>
-                                <div class="info-value">{% if contabil.metodo_importacao %}<span class="badge bg-dept-orange-subtle fs-6"><i class="bi bi-download me-1 text-dept-orange"></i>{{ contabil.metodo_importacao }}</span>{% else %}<span class="text-muted">Não informado</span>{% endif %}</div>
+                                {% set placeholder_metodo %}<span class="text-muted">Não informado</span>{% endset %}
+                                {% set mi_map = {'importado': 'Importado', 'digitado': 'Digitado'} %}
+                                {% set mi_items = [] %}
+                                {% if contabil.metodo_importacao is iterable and contabil.metodo_importacao is not string %}
+                                    {% set mi_items = contabil.metodo_importacao %}
+                                {% elif contabil.metodo_importacao %}
+                                    {% set mi_items = [contabil.metodo_importacao] %}
+                                {% endif %}
+                                {% set mi_ns = namespace(items=[]) %}
+                                {% for item in mi_items %}
+                                    {% set mi_ns.items = mi_ns.items + [mi_map.get(item, item)] %}
+                                {% endfor %}
+                                <div class="info-value">{{ render_badge_list(mi_ns.items, 'badge bg-dept-orange-subtle text-dept-orange fs-6', 'bi-download', placeholder_metodo) }}</div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- allow selecting multiple accounting import methods
- persist multiple import methods and display them

## Testing
- `python -m py_compile app/forms.py app/models/tables.py app/controllers/routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a5d4046bd48330b5aee3e81e8ea8d7

## Summary by Sourcery

Enable multi-select import methods for the accounting department by migrating the model to JSON storage, updating the form to use multiple checkboxes, adjusting controller logic for list handling, and enhancing templates to show multiple selections.

New Features:
- Allow selecting and persisting multiple import methods for the accounting department

Enhancements:
- Change departamento.metodo_importacao column to store JSON arrays instead of a single string
- Convert the método_importacao form field to a SelectMultipleField and update its data binding in the controller
- Update templates to render metodo_importacao as a set of checkboxes and display multiple badges in the detail view