### PR TITLE
Make prefeitura links clickable in company view

### DIFF
--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -224,7 +224,9 @@
                                         </div>
                                         <div class="col-md-3">
                                             {% if acesso.link %}
-                                                <a href="{{ acesso.link }}" target="_blank" rel="noopener noreferrer" class="form-control text-primary text-decoration-underline">{{ acesso.link }}</a>
+                                                <a href="{{ acesso.link }}" target="_blank" rel="noopener noreferrer"
+                                                   class="form-control d-block text-primary text-decoration-underline text-truncate"
+                                                   title="{{ acesso.link }}">{{ acesso.link }}</a>
                                             {% else %}
                                                 <input type="text" class="form-control" value="" readonly>
                                             {% endif %}

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -223,7 +223,11 @@
                                             <input type="text" class="form-control" value="{{ acesso.cidade or '' }}" readonly>
                                         </div>
                                         <div class="col-md-3">
-                                            <input type="text" class="form-control" value="{{ acesso.link or '' }}" readonly>
+                                            {% if acesso.link %}
+                                                <a href="{{ acesso.link }}" target="_blank" rel="noopener noreferrer" class="form-control text-primary text-decoration-underline">{{ acesso.link }}</a>
+                                            {% else %}
+                                                <input type="text" class="form-control" value="" readonly>
+                                            {% endif %}
                                         </div>
                                         <div class="col-md-3">
                                             <input type="text" class="form-control" value="{{ acesso.usuario or '' }}" readonly>


### PR DESCRIPTION
## Summary
- Render prefeitura links as anchor tags that open in new tab.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a5e0248e508330b25f942d6b204e22

## Summary by Sourcery

Render prefeitura links in the company detail view as clickable anchor tags that open in a new tab, with a fallback to an empty readonly input when no link is provided.

Enhancements:
- Change prefeitura link field from a readonly text input to an anchor tag with target and rel attributes when a link exists
- Keep an empty readonly input for cases where no prefeitura link is available