### PR TITLE
Enable password visibility toggles on login and registration

### DIFF
--- a/app/static/javascript/password_toggle.js
+++ b/app/static/javascript/password_toggle.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-password-toggle]').forEach((button) => {
+    const targetSelector = button.getAttribute('data-password-toggle');
+    const input = document.querySelector(targetSelector);
+    if (!input) return;
+    button.addEventListener('click', () => {
+      const type = input.getAttribute('type') === 'password' ? 'text' : 'password';
+      input.setAttribute('type', type);
+      const icon = button.querySelector('i');
+      if (icon) {
+        if (icon.classList.contains('fa-eye') || icon.classList.contains('fa-eye-slash')) {
+          icon.classList.toggle('fa-eye');
+          icon.classList.toggle('fa-eye-slash');
+        }
+        if (icon.classList.contains('bi-eye') || icon.classList.contains('bi-eye-slash')) {
+          icon.classList.toggle('bi-eye');
+          icon.classList.toggle('bi-eye-slash');
+        }
+      }
+    });
+  });
+});

--- a/app/templates/admin/novo_usuario.html
+++ b/app/templates/admin/novo_usuario.html
@@ -104,7 +104,7 @@
                         <div class="input-group">
                             <span class="input-group-text"><i class="bi bi-lock"></i></span>
                             {{ form.password(class="form-control", placeholder="Senha", type="password", id="password") }}
-                            <button class="btn btn-outline-secondary" type="button" id="togglePassword">
+                            <button class="btn btn-outline-secondary" type="button" data-password-toggle="#password">
                                 <i class="bi bi-eye"></i>
                             </button>
                         </div>
@@ -120,7 +120,7 @@
                         <div class="input-group">
                             <span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
                             {{ form.confirm_password(class="form-control", placeholder="Confirme a senha", type="password", id="confirmPassword") }}
-                            <button class="btn btn-outline-secondary" type="button" id="toggleConfirmPassword">
+                            <button class="btn btn-outline-secondary" type="button" data-password-toggle="#confirmPassword">
                                 <i class="bi bi-eye"></i>
                             </button>
                         </div>
@@ -151,26 +151,9 @@
 </div>
 
 {% block scripts %}
+<script src="{{ url_for('static', filename='javascript/password_toggle.js') }}"></script>
 <script>
 document.addEventListener("DOMContentLoaded", function () {
-    // Toggle para mostrar/ocultar senhas
-    function setupPasswordToggle(passwordId, toggleId) {
-        const passwordField = document.querySelector(`#${passwordId}`);
-        const toggleBtn = document.querySelector(`#${toggleId}`);
-        
-        if (passwordField && toggleBtn) {
-            toggleBtn.addEventListener('click', function() {
-                const type = passwordField.getAttribute('type') === 'password' ? 'text' : 'password';
-                passwordField.setAttribute('type', type);
-                this.querySelector('i').classList.toggle('bi-eye');
-                this.querySelector('i').classList.toggle('bi-eye-slash');
-            });
-        }
-    }
-
-    setupPasswordToggle('password', 'togglePassword');
-    setupPasswordToggle('confirmPassword', 'toggleConfirmPassword');
-
     // Validação simples de confirmação de senha
     const passwordField = document.querySelector('#password');
     const confirmPasswordField = document.querySelector('#confirmPassword');

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -49,7 +49,7 @@
                 <div class="input-group">
                     <span class="input-group-text"><i class="fas fa-lock"></i></span>
                     {{ form.password(class="form-control", id="password", placeholder="Digite sua senha") }}
-                    <button class="btn btn-outline-secondary" type="button" id="togglePassword">
+                    <button class="btn btn-outline-secondary" type="button" data-password-toggle="#password">
                         <i class="fas fa-eye"></i>
                     </button>
                 </div>
@@ -70,20 +70,8 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-
+    <script src="{{ url_for('static', filename='javascript/password_toggle.js') }}"></script>
     <script>
-        const togglePassword = document.querySelector('#togglePassword');
-        const password = document.querySelector('#password');
-
-        if (togglePassword && password) {
-            togglePassword.addEventListener('click', function () {
-                const type = password.getAttribute('type') === 'password' ? 'text' : 'password';
-                password.setAttribute('type', type);
-                this.querySelector('i').classList.toggle('fa-eye');
-                this.querySelector('i').classList.toggle('fa-eye-slash');
-            });
-        }
-
         document.addEventListener('DOMContentLoaded', function() {
             const alerts = document.querySelectorAll('.alert');
             alerts.forEach(function(alert) {


### PR DESCRIPTION
## Summary
- add reusable password visibility toggle script
- hook login and registration forms to new script

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a6222c5cb88330a71d0cbc2441d2c4

## Summary by Sourcery

Enable password visibility toggles on login and registration by extracting a reusable script and updating templates to use data-password-toggle attributes

New Features:
- Add a reusable password_toggle.js script to handle show/hide functionality via data attributes
- Integrate the password visibility toggle into both login and registration forms by replacing inline handlers with data-password-toggle attributes

Enhancements:
- Remove duplicated inline JavaScript for password toggles and import the centralized password_toggle.js script in templates