### PR TITLE
Fix password visibility toggle and add company tax report

### DIFF
--- a/app/templates/admin/novo_usuario.html
+++ b/app/templates/admin/novo_usuario.html
@@ -104,9 +104,6 @@
                         <div class="input-group">
                             <span class="input-group-text"><i class="bi bi-lock"></i></span>
                             {{ form.password(class="form-control", placeholder="Senha", type="password", id="password") }}
-                            <button class="btn btn-outline-secondary" type="button" id="togglePassword">
-                                <i class="bi bi-eye"></i>
-                            </button>
                         </div>
                         {% for error in form.password.errors %}
                             <div class="form-text text-danger">
@@ -120,9 +117,6 @@
                         <div class="input-group">
                             <span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
                             {{ form.confirm_password(class="form-control", placeholder="Confirme a senha", type="password", id="confirmPassword") }}
-                            <button class="btn btn-outline-secondary" type="button" id="toggleConfirmPassword">
-                                <i class="bi bi-eye"></i>
-                            </button>
                         </div>
                         {% for error in form.confirm_password.errors %}
                             <div class="form-text text-danger">
@@ -152,25 +146,7 @@
 
 {% block scripts %}
 <script>
-document.addEventListener("DOMContentLoaded", function () {
-    // Toggle para mostrar/ocultar senhas
-    function setupPasswordToggle(passwordId, toggleId) {
-        const passwordField = document.querySelector(`#${passwordId}`);
-        const toggleBtn = document.querySelector(`#${toggleId}`);
-        
-        if (passwordField && toggleBtn) {
-            toggleBtn.addEventListener('click', function() {
-                const type = passwordField.getAttribute('type') === 'password' ? 'text' : 'password';
-                passwordField.setAttribute('type', type);
-                this.querySelector('i').classList.toggle('bi-eye');
-                this.querySelector('i').classList.toggle('bi-eye-slash');
-            });
-        }
-    }
-
-    setupPasswordToggle('password', 'togglePassword');
-    setupPasswordToggle('confirmPassword', 'toggleConfirmPassword');
-
+document.addEventListener('DOMContentLoaded', function () {
     // Validação simples de confirmação de senha
     const passwordField = document.querySelector('#password');
     const confirmPasswordField = document.querySelector('#confirmPassword');
@@ -238,8 +214,8 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Auto-dismiss alerts
     const alerts = document.querySelectorAll('.alert-dismissible');
-    alerts.forEach(function(alert) {
-        setTimeout(function() {
+    alerts.forEach(function (alert) {
+        setTimeout(function () {
             if (alert && bootstrap.Alert) {
                 const bsAlert = new bootstrap.Alert(alert);
                 bsAlert.close();

--- a/app/templates/admin/relatorio_empresas.html
+++ b/app/templates/admin/relatorio_empresas.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}Relatório de Empresas{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h1 class="mb-4">Empresas por Regime de Tributação</h1>
+    <div id="chart-container">
+        {{ chart_div|safe }}
+    </div>
+    <div id="empresa-list" class="mt-4 d-flex justify-content-center"></div>
+</div>
+<script>
+    const empresasBySlice = {{ empresas_por_slice|tojson }};
+    const chart = document.getElementById('empresa-tributacao-chart');
+    if (chart) {
+        chart.on('plotly_click', function(data){
+            const label = data.points[0].x || data.points[0].label;
+            const empresas = empresasBySlice[label] || [];
+            const container = document.getElementById('empresa-list');
+            if (!empresas.length) {
+                container.innerHTML = '<p class="text-center">Nenhuma empresa encontrada.</p>';
+                return;
+            }
+            let html = '<div class="table-responsive"><table class="table table-striped w-auto text-start"><thead><tr><th>Código</th><th>Nome</th><th>CNPJ</th></tr></thead><tbody>';
+            empresas.forEach(e => {
+                const nome = e.nome ? e.nome.toUpperCase() : '';
+                const cnpj = e.cnpj || '';
+                const codigo = e.codigo || '';
+                html += `<tr><td>${codigo}</td><td>${nome}</td><td>${cnpj}</td></tr>`;
+            });
+            html += '</tbody></table></div>';
+            container.innerHTML = html;
+        });
+    }
+</script>
+{% endblock %}

--- a/app/templates/admin/relatorios.html
+++ b/app/templates/admin/relatorios.html
@@ -51,7 +51,7 @@
                     </ul>
                 </div>
                 <div class="card-footer bg-transparent border-0">
-                    <a href="{{ url_for('listar_empresas') }}" class="btn btn-primary w-100">
+                    <a href="{{ url_for('relatorio_empresas') }}" class="btn btn-primary w-100">
                         <i class="bi bi-arrow-right-circle me-2"></i>Acessar Relatório
                     </a>
                 </div>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -72,22 +72,27 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
     <script>
-        const togglePassword = document.querySelector('#togglePassword');
-        const password = document.querySelector('#password');
+        document.addEventListener('DOMContentLoaded', function () {
+            const togglePassword = document.getElementById('togglePassword');
+            const password = document.getElementById('password');
 
-        if (togglePassword && password) {
-            togglePassword.addEventListener('click', function () {
-                const type = password.getAttribute('type') === 'password' ? 'text' : 'password';
-                password.setAttribute('type', type);
-                this.querySelector('i').classList.toggle('fa-eye');
-                this.querySelector('i').classList.toggle('fa-eye-slash');
-            });
-        }
+            if (togglePassword && password) {
+                togglePassword.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    const type = password.getAttribute('type') === 'password' ? 'text' : 'password';
+                    password.setAttribute('type', type);
 
-        document.addEventListener('DOMContentLoaded', function() {
+                    const icon = this.querySelector('i');
+                    if (icon) {
+                        icon.classList.toggle('fa-eye');
+                        icon.classList.toggle('fa-eye-slash');
+                    }
+                });
+            }
+
             const alerts = document.querySelectorAll('.alert');
-            alerts.forEach(function(alert) {
-                setTimeout(function() {
+            alerts.forEach(function (alert) {
+                setTimeout(function () {
                     if (alert && bootstrap.Alert) {
                         const bsAlert = new bootstrap.Alert(alert);
                         bsAlert.close();


### PR DESCRIPTION
## Summary
- fix password visibility toggle so the eye icon properly reveals or hides the password on the login page
- remove the eye icon and toggle script from the new-user registration page where it's no longer needed
- add an interactive report grouping companies by taxation regime (Simples Nacional, Lucro Presumido, Lucro Real)

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a626ea2f84833093c6d3ee17f1ea5d

## Summary by Sourcery

Add a company taxation report with an interactive bar chart and improve the login password visibility toggle while cleaning up registration page scripts

New Features:
- Add interactive company tax report route and view with Plotly bar chart grouping companies by taxation regime
- Introduce relatorio_empresas.html template featuring click-to-list of companies per regime

Bug Fixes:
- Fix password visibility toggle on the login page to properly reveal and hide passwords

Enhancements:
- Refactor login page JS for password toggle initialization after DOM load and safe icon toggling
- Remove password visibility controls and related scripts from the new-user registration page
- Update admin reports overview to link to the new company taxation report