### PR TITLE
Remove password visibility toggle icon

### DIFF
--- a/app/templates/admin/novo_usuario.html
+++ b/app/templates/admin/novo_usuario.html
@@ -104,9 +104,6 @@
                         <div class="input-group">
                             <span class="input-group-text"><i class="bi bi-lock"></i></span>
                             {{ form.password(class="form-control", placeholder="Senha", type="password", id="password") }}
-                            <button class="btn btn-outline-secondary" type="button" id="togglePassword">
-                                <i class="bi bi-eye"></i>
-                            </button>
                         </div>
                         {% for error in form.password.errors %}
                             <div class="form-text text-danger">
@@ -120,9 +117,6 @@
                         <div class="input-group">
                             <span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
                             {{ form.confirm_password(class="form-control", placeholder="Confirme a senha", type="password", id="confirmPassword") }}
-                            <button class="btn btn-outline-secondary" type="button" id="toggleConfirmPassword">
-                                <i class="bi bi-eye"></i>
-                            </button>
                         </div>
                         {% for error in form.confirm_password.errors %}
                             <div class="form-text text-danger">
@@ -153,28 +147,6 @@
 {% block scripts %}
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-    function setupPasswordToggle(toggleId, inputId) {
-        const toggle = document.getElementById(toggleId);
-        const input = document.getElementById(inputId);
-
-        if (toggle && input) {
-            toggle.addEventListener('click', function (e) {
-                e.preventDefault();
-                const type = input.getAttribute('type') === 'password' ? 'text' : 'password';
-                input.setAttribute('type', type);
-
-                const icon = this.querySelector('i');
-                if (icon) {
-                    icon.classList.toggle('bi-eye');
-                    icon.classList.toggle('bi-eye-slash');
-                }
-            });
-        }
-    }
-
-    setupPasswordToggle('togglePassword', 'password');
-    setupPasswordToggle('toggleConfirmPassword', 'confirmPassword');
-
     // Validação simples de confirmação de senha
     const passwordField = document.querySelector('#password');
     const confirmPasswordField = document.querySelector('#confirmPassword');

--- a/app/templates/edit_user.html
+++ b/app/templates/edit_user.html
@@ -122,9 +122,6 @@
                                         <i class="bi bi-lock"></i>
                                     </span>
                                     <input type="password" name="new_password" class="form-control" placeholder="Digite a nova senha">
-                                    <button class="btn btn-outline-secondary" type="button" onclick="togglePassword(this)">
-                                        <i class="bi bi-eye"></i>
-                                    </button>
                                 </div>
                             </div>
                             
@@ -135,9 +132,6 @@
                                         <i class="bi bi-lock-fill"></i>
                                     </span>
                                     <input type="password" name="confirm_new_password" class="form-control" placeholder="Confirme a nova senha">
-                                    <button class="btn btn-outline-secondary" type="button" onclick="togglePassword(this)">
-                                        <i class="bi bi-eye"></i>
-                                    </button>
                                 </div>
                             </div>
                         </div>
@@ -160,22 +154,6 @@
 
 {% block scripts %}
 <script>
-// Toggle para mostrar/ocultar senha
-function togglePassword(button) {
-    const input = button.previousElementSibling;
-    const icon = button.querySelector('i');
-    
-    if (input.type === 'password') {
-        input.type = 'text';
-        icon.classList.remove('bi-eye');
-        icon.classList.add('bi-eye-slash');
-    } else {
-        input.type = 'password';
-        icon.classList.remove('bi-eye-slash');
-        icon.classList.add('bi-eye');
-    }
-}
-
 // Auto-dismiss alerts
 document.addEventListener("DOMContentLoaded", function () {
     const alerts = document.querySelectorAll('.alert-dismissible');

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -49,9 +49,6 @@
                 <div class="input-group">
                     <span class="input-group-text"><i class="fas fa-lock"></i></span>
                     {{ form.password(class="form-control", id="password", placeholder="Digite sua senha") }}
-                    <button class="btn btn-outline-secondary" type="button" id="togglePassword">
-                        <i class="fas fa-eye"></i>
-                    </button>
                 </div>
                 {% for error in form.password.errors %}
                     <div class="text-danger small mt-1">{{ error }}</div>
@@ -73,23 +70,6 @@
 
     <script>
         document.addEventListener('DOMContentLoaded', function () {
-            const togglePassword = document.getElementById('togglePassword');
-            const password = document.getElementById('password');
-
-            if (togglePassword && password) {
-                togglePassword.addEventListener('click', function (e) {
-                    e.preventDefault();
-                    const type = password.getAttribute('type') === 'password' ? 'text' : 'password';
-                    password.setAttribute('type', type);
-
-                    const icon = this.querySelector('i');
-                    if (icon) {
-                        icon.classList.toggle('fa-eye');
-                        icon.classList.toggle('fa-eye-slash');
-                    }
-                });
-            }
-
             const alerts = document.querySelectorAll('.alert');
             alerts.forEach(function (alert) {
                 setTimeout(function () {


### PR DESCRIPTION
## Summary
- remove eye icon and toggle script from login form
- drop password visibility buttons from user edit and new user forms

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a6f9dc69ec83308e71083e0c9c7b56

## Summary by Sourcery

Enhancements:
- Remove password visibility toggle icons and associated JavaScript from login, new user, and edit user forms