### PR TITLE
Add password visibility toggles to user forms

### DIFF
--- a/app/templates/admin/novo_usuario.html
+++ b/app/templates/admin/novo_usuario.html
@@ -104,6 +104,9 @@
                         <div class="input-group">
                             <span class="input-group-text"><i class="bi bi-lock"></i></span>
                             {{ form.password(class="form-control", placeholder="Senha", type="password", id="password") }}
+                            <button type="button" class="btn btn-outline-secondary toggle-password" data-target="#password">
+                                <i class="bi bi-eye"></i>
+                            </button>
                         </div>
                         {% for error in form.password.errors %}
                             <div class="form-text text-danger">
@@ -117,6 +120,9 @@
                         <div class="input-group">
                             <span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
                             {{ form.confirm_password(class="form-control", placeholder="Confirme a senha", type="password", id="confirmPassword") }}
+                            <button type="button" class="btn btn-outline-secondary toggle-password" data-target="#confirmPassword">
+                                <i class="bi bi-eye"></i>
+                            </button>
                         </div>
                         {% for error in form.confirm_password.errors %}
                             <div class="form-text text-danger">
@@ -174,6 +180,20 @@ document.addEventListener('DOMContentLoaded', function () {
         passwordField.addEventListener('input', validatePasswordMatch);
         confirmPasswordField.addEventListener('input', validatePasswordMatch);
     }
+
+    // Toggle de visualização de senha
+    document.querySelectorAll('.toggle-password').forEach(function(button) {
+        button.addEventListener('click', function() {
+            const target = document.querySelector(this.getAttribute('data-target'));
+            if (target) {
+                const type = target.getAttribute('type') === 'password' ? 'text' : 'password';
+                target.setAttribute('type', type);
+                const icon = this.querySelector('i');
+                icon.classList.toggle('bi-eye');
+                icon.classList.toggle('bi-eye-slash');
+            }
+        });
+    });
 
     // Validação de username em tempo real
     const usernameField = document.querySelector('#username');

--- a/app/templates/edit_user.html
+++ b/app/templates/edit_user.html
@@ -121,17 +121,23 @@
                                     <span class="input-group-text">
                                         <i class="bi bi-lock"></i>
                                     </span>
-                                    <input type="password" name="new_password" class="form-control" placeholder="Digite a nova senha">
+                                    <input type="password" name="new_password" class="form-control" placeholder="Digite a nova senha" id="new_password">
+                                    <button type="button" class="btn btn-outline-secondary toggle-password" data-target="#new_password">
+                                        <i class="bi bi-eye"></i>
+                                    </button>
                                 </div>
                             </div>
-                            
+
                             <div class="col-md-6 mb-3">
                                 <label class="form-label fw-semibold">Confirmar Nova Senha</label>
                                 <div class="input-group">
                                     <span class="input-group-text">
                                         <i class="bi bi-lock-fill"></i>
                                     </span>
-                                    <input type="password" name="confirm_new_password" class="form-control" placeholder="Confirme a nova senha">
+                                    <input type="password" name="confirm_new_password" class="form-control" placeholder="Confirme a nova senha" id="confirm_new_password">
+                                    <button type="button" class="btn btn-outline-secondary toggle-password" data-target="#confirm_new_password">
+                                        <i class="bi bi-eye"></i>
+                                    </button>
                                 </div>
                             </div>
                         </div>
@@ -154,7 +160,6 @@
 
 {% block scripts %}
 <script>
-// Auto-dismiss alerts
 document.addEventListener("DOMContentLoaded", function () {
     const alerts = document.querySelectorAll('.alert-dismissible');
     alerts.forEach(function(alert) {
@@ -164,6 +169,19 @@ document.addEventListener("DOMContentLoaded", function () {
                 bsAlert.close();
             }
         }, 5000);
+    });
+
+    document.querySelectorAll('.toggle-password').forEach(function(button) {
+        button.addEventListener('click', function() {
+            const target = document.querySelector(this.getAttribute('data-target'));
+            if (target) {
+                const type = target.getAttribute('type') === 'password' ? 'text' : 'password';
+                target.setAttribute('type', type);
+                const icon = this.querySelector('i');
+                icon.classList.toggle('bi-eye');
+                icon.classList.toggle('bi-eye-slash');
+            }
+        });
     });
 });
 </script>

--- a/app/templates/list_users.html
+++ b/app/templates/list_users.html
@@ -122,11 +122,21 @@
           </div>
           <div class="mb-3">
             {{ form.password.label(class="form-label") }}
-            {{ form.password(class="form-control") }}
+            <div class="input-group">
+              {{ form.password(class="form-control", id="modal_password") }}
+              <button type="button" class="btn btn-outline-secondary toggle-password" data-target="#modal_password">
+                <i class="bi bi-eye"></i>
+              </button>
+            </div>
           </div>
           <div class="mb-3">
             {{ form.confirm_password.label(class="form-label") }}
-            {{ form.confirm_password(class="form-control") }}
+            <div class="input-group">
+              {{ form.confirm_password(class="form-control", id="modal_confirm_password") }}
+              <button type="button" class="btn btn-outline-secondary toggle-password" data-target="#modal_confirm_password">
+                <i class="bi bi-eye"></i>
+              </button>
+            </div>
           </div>
           <div class="mb-3">
             {{ form.role.label(class="form-label") }}
@@ -170,6 +180,20 @@ document.addEventListener("DOMContentLoaded", function () {
     const tooltipTriggerList = [].slice.call(document.querySelectorAll('[title]'));
     tooltipTriggerList.map(function (tooltipTriggerEl) {
         return new bootstrap.Tooltip(tooltipTriggerEl);
+    });
+
+    // Toggle de visualização de senha no modal
+    document.querySelectorAll('.toggle-password').forEach(function(button) {
+        button.addEventListener('click', function() {
+            const target = document.querySelector(this.getAttribute('data-target'));
+            if (target) {
+                const type = target.getAttribute('type') === 'password' ? 'text' : 'password';
+                target.setAttribute('type', type);
+                const icon = this.querySelector('i');
+                icon.classList.toggle('bi-eye');
+                icon.classList.toggle('bi-eye-slash');
+            }
+        });
     });
 });
 

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -49,6 +49,9 @@
                 <div class="input-group">
                     <span class="input-group-text"><i class="fas fa-lock"></i></span>
                     {{ form.password(class="form-control", id="password", placeholder="Digite sua senha") }}
+                    <span class="input-group-text" style="cursor: pointer;">
+                        <i class="fas fa-eye" id="togglePassword"></i>
+                    </span>
                 </div>
                 {% for error in form.password.errors %}
                     <div class="text-danger small mt-1">{{ error }}</div>
@@ -79,6 +82,17 @@
                     }
                 }, 5000);
             });
+
+            const togglePassword = document.querySelector('#togglePassword');
+            const passwordField = document.querySelector('#password');
+            if (togglePassword && passwordField) {
+                togglePassword.addEventListener('click', function () {
+                    const type = passwordField.getAttribute('type') === 'password' ? 'text' : 'password';
+                    passwordField.setAttribute('type', type);
+                    this.classList.toggle('fa-eye');
+                    this.classList.toggle('fa-eye-slash');
+                });
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- allow password visibility toggle on login form
- enable show/hide password buttons on user creation and edit interfaces

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a6fe650aa08330b8a26ca3061a0627