### PR TITLE
Add prefeitura access to company registration

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -77,6 +77,8 @@ class EmpresaForm(FlaskForm):
         ('QUESTOR_NET', 'Questor Net'), ('SIEG', 'Sieg'), ('SIEG_TAG', 'Sieg - Utiliza TAGs')
     ], validators=[Optional()])
     sistema_utilizado = StringField('Sistema Utilizado', validators=[Optional()])
+    links_prefeitura_json = HiddenField('Links Prefeitura', validators=[Optional()])
+    observacao_prefeitura = TextAreaField('Observação', validators=[Optional()])
     submit = SubmitField('Cadastrar Empresa')
 
 class EditUserForm(FlaskForm):
@@ -103,8 +105,6 @@ class DepartamentoFiscalForm(DepartamentoForm):
         ('nfce_xml_sieg', 'NFCe por XML - Sieg'), ('nfce_xml_cliente', 'NFCe por XML - Copiado do cliente'),
         ('nenhum', 'Não importa nada')], validators=[Optional()])
     observacao_importacao = TextAreaField('Observação', validators=[Optional()])
-    links_prefeitura_json = HiddenField('Links Prefeitura', validators=[Optional()])
-    observacao_prefeitura = TextAreaField('Observação', validators=[Optional()])
     forma_movimento = SelectField('Envio de Documento', choices=[
         ('', 'Selecione'), ('Digital', 'Digital'), ('Fisico', 'Físico'), ('Digital e Físico', 'Digital e Físico')
     ], validators=[Optional()])

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -72,6 +72,8 @@ class Empresa(db.Model):
     regime_lancamento = db.Column(db.Enum(RegimeLancamento), nullable=False)
     sistemas_consultorias = db.Column(JsonString(255))
     sistema_utilizado = db.Column(db.String(150))
+    links_prefeitura = db.Column(JsonString(255))
+    observacao_prefeitura = db.Column(db.String(200))
     codigo_empresa = db.Column(db.String(100), nullable=False)
 
     def __repr__(self):
@@ -85,14 +87,12 @@ class Departamento(db.Model):
     responsavel = db.Column(db.String(100))
     descricao = db.Column(db.String(200))
     formas_importacao = db.Column(JsonString(255))
-    links_prefeitura = db.Column(JsonString(255))
     forma_movimento = db.Column(db.String(20))
     envio_digital = db.Column(JsonString(200))
     envio_fisico = db.Column(JsonString(200))
     malote_coleta = db.Column(db.String(20))
     observacao_movimento = db.Column(db.String(200))
     observacao_importacao = db.Column(db.String(200))
-    observacao_prefeitura = db.Column(db.String(200))
     observacao_contato = db.Column(db.String(200))
     metodo_importacao = db.Column(JsonString(255))
     controle_relatorios = db.Column(JsonString(255))

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -59,22 +59,6 @@
                     </div>
                 </div>
 
-                <div class="row g-4 mb-4">
-                    <div class="col-12">
-                        <div id="links-prefeitura-container"></div>
-                        <button type="button" class="btn btn-outline-primary btn-sm mt-2" id="add-prefeitura">
-                            <i class="bi bi-plus-circle"></i> Adicionar Link
-                        </button>
-                        {{ form.links_prefeitura_json(id='links_prefeitura_json') }}
-                        <button type="button" class="btn btn-outline-primary btn-sm mt-2" id="add-obs-prefeitura">
-                            <i class="bi bi-plus-circle"></i> Adicionar Observação
-                        </button>
-                        <div id="obs-prefeitura-container" class="form-floating mt-2" style="display:none;">
-                            {{ form.observacao_prefeitura(class="form-control", id="observacao_prefeitura", placeholder="Observação", style="height: 100px; overflow-y: auto;") }}
-                            {{ form.observacao_prefeitura.label(class="form-label") }}
-                        </div>
-                    </div>
-                </div>
 
                 <div class="row mb-4">
                     <div class="col-12">
@@ -233,7 +217,6 @@
 <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
 <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
 <script src="{{ url_for('static', filename='javascript/contatos.js') }}"></script>
-<script src="{{ url_for('static', filename='javascript/prefeituras.js') }}"></script>
 <script src="{{ url_for('static', filename='javascript/forma_movimento.js') }}"></script>
 <script src="{{ url_for('static', filename='javascript/observacao.js') }}"></script>
 
@@ -241,7 +224,6 @@
     document.addEventListener("DOMContentLoaded", function () {
     
     setupObservacao('add-obs-importacao', 'obs-importacao-container', 'observacao_importacao');
-    setupObservacao('add-obs-prefeitura', 'obs-prefeitura-container', 'observacao_prefeitura');
     setupObservacao('add-obs-envio', 'obs-envio-container', 'observacao_movimento');
     setupObservacao('add-obs-contato', 'obs-contato-container', 'observacao_contato');
 
@@ -314,7 +296,6 @@
     });
     
     setupContatos('contatos-container', 'add-contato', 'contatos_json');
-    setupPrefeituras('links-prefeitura-container', 'add-prefeitura', 'links_prefeitura_json');
     setupFormaMovimento('forma_movimento', 'envio_digital_container', 'envio_fisico_container');
     setupMalote('malote_checkbox', 'malote_coleta');
 

--- a/app/templates/empresas/cadastrar.html
+++ b/app/templates/empresas/cadastrar.html
@@ -189,6 +189,29 @@
                 <div class="row mb-4">
                     <div class="col-12">
                         <h5 class="text-primary border-bottom pb-2 mb-3">
+                            <i class="bi bi-building me-2"></i>Acesso à Prefeitura
+                        </h5>
+                    </div>
+                </div>
+
+                <div class="row g-4 mb-4">
+                    <div class="col-12">
+                        <div id="links-prefeitura-container"></div>
+                        <button type="button" class="btn btn-outline-primary btn-sm mt-2" id="add-prefeitura">
+                            <i class="bi bi-plus-circle"></i> Adicionar Link
+                        </button>
+                        {{ form.links_prefeitura_json(id='links_prefeitura_json') }}
+                        <button type="button" class="btn btn-outline-primary btn-sm mt-2" id="add_obs_prefeitura"><i class="bi bi-plus-circle"></i> Adicionar Observação</button>
+                        <div id="obs_prefeitura_container" class="form-floating mt-2" style="display:none;">
+                            {{ form.observacao_prefeitura(class="form-control", id="observacao_prefeitura", placeholder="Observação", style="height: 100px; overflow-y: auto;") }}
+                            {{ form.observacao_prefeitura.label }}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row mb-4">
+                    <div class="col-12">
+                        <h5 class="text-primary border-bottom pb-2 mb-3">
                             <i class="bi bi-gear me-2"></i>Sistemas e Consultorias
                         </h5>
                     </div>
@@ -262,8 +285,12 @@
 </div>
 
 {% block scripts %}
+<script src="{{ url_for('static', filename='javascript/prefeituras.js') }}"></script>
+<script src="{{ url_for('static', filename='javascript/observacao.js') }}"></script>
 <script>
 document.addEventListener("DOMContentLoaded", function () {
+    setupPrefeituras('links-prefeitura-container', 'add-prefeitura', 'links_prefeitura_json');
+    setupObservacao('add_obs_prefeitura', 'obs_prefeitura_container', 'observacao_prefeitura');
     // Auto-dismiss existing alerts
     const autoDismiss = (alertEl) => {
         setTimeout(() => {

--- a/app/templates/empresas/departamentos.html
+++ b/app/templates/empresas/departamentos.html
@@ -53,21 +53,6 @@
                     </div>
                 </div>
 
-                <h5 class="text-dept-blue border-bottom pb-2 mb-3"><i class="bi bi-building me-2"></i>Acesso à Prefeitura</h5>
-                <div class="row g-4 mb-4 align-items-stretch">
-                    <div class="col-12">
-                        <div id="links-prefeitura-container"></div>
-                        <button type="button" class="btn btn-outline-dept-blue btn-sm mt-2" id="add-prefeitura">
-                            <i class="bi bi-plus-circle"></i> Adicionar Link
-                        </button>
-                        {{ fiscal_form.links_prefeitura_json(id='links_prefeitura_json') }}
-                        <button type="button" class="btn btn-outline-dept-blue btn-sm mt-2" id="fiscal_add_obs_prefeitura"><i class="bi bi-plus-circle"></i> Adicionar Observação</button>
-                        <div id="fiscal_obs_prefeitura_container" class="form-floating mt-2" style="display:none;">
-                            {{ fiscal_form.observacao_prefeitura(class="form-control", id="fiscal_observacao_prefeitura", placeholder="Observação", style="height: 100px; overflow-y: auto;") }}
-                            {{ fiscal_form.observacao_prefeitura.label }}
-                        </div>
-                    </div>
-                </div>
 
                 <h5 class="text-dept-blue border-bottom pb-2 mb-3"><i class="bi bi-cloud-upload me-2"></i>Envio de Documento e Contato</h5>
                 <div class="row g-4 mb-4 align-items-stretch">
@@ -379,20 +364,17 @@
 <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
 <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
 <script src="{{ url_for('static', filename='javascript/contatos.js') }}"></script>
-<script src="{{ url_for('static', filename='javascript/prefeituras.js') }}"></script>
 <script src="{{ url_for('static', filename='javascript/forma_movimento.js') }}"></script>
 <script src="{{ url_for('static', filename='javascript/observacao.js') }}"></script>
 
 <script>
 document.addEventListener("DOMContentLoaded", function () {
     setupContatos('contatos-container', 'add-contato', 'contatos_json');
-    setupPrefeituras('links-prefeitura-container', 'add-prefeitura', 'links_prefeitura_json');
     setupFormaMovimento('fiscal_forma_movimento', 'fiscal_envio_digital', 'fiscal_envio_fisico');
     setupFormaMovimento('contabil_forma_movimento', 'contabil_envio_digital', 'contabil_envio_fisico');
     setupMalote('fiscal_malote_checkbox', 'fiscal_malote_coleta');
     setupMalote('contabil_malote_checkbox', 'contabil_malote_coleta');
     setupObservacao('fiscal_add_obs_importacao', 'fiscal_obs_importacao_container', 'fiscal_observacao_importacao');
-    setupObservacao('fiscal_add_obs_prefeitura', 'fiscal_obs_prefeitura_container', 'fiscal_observacao_prefeitura');
     setupObservacao('fiscal_add_obs_envio', 'fiscal_obs_envio_container', 'fiscal_observacao_movimento');
     setupObservacao('fiscal_add_obs_contato', 'fiscal_obs_contato_container', 'fiscal_observacao_contato');
     setupObservacao('contabil_add_obs_envio', 'contabil_obs_envio_container', 'contabil_observacao_movimento');

--- a/app/templates/empresas/editar_empresa.html
+++ b/app/templates/empresas/editar_empresa.html
@@ -168,6 +168,29 @@
                     </div>
                 </div>
 
+                <div class="row mb-4">
+                    <div class="col-12">
+                        <h5 class="text-primary border-bottom pb-2 mb-3">
+                            <i class="bi bi-building me-2"></i>Acesso à Prefeitura
+                        </h5>
+                    </div>
+                </div>
+
+                <div class="row g-4 mb-4">
+                    <div class="col-12">
+                        <div id="links-prefeitura-container"></div>
+                        <button type="button" class="btn btn-outline-primary btn-sm mt-2" id="add-prefeitura">
+                            <i class="bi bi-plus-circle"></i> Adicionar Link
+                        </button>
+                        {{ empresa_form.links_prefeitura_json(id='links_prefeitura_json') }}
+                        <button type="button" class="btn btn-outline-primary btn-sm mt-2" id="add_obs_prefeitura"><i class="bi bi-plus-circle"></i> Adicionar Observação</button>
+                        <div id="obs_prefeitura_container" class="form-floating mt-2" style="display:none;">
+                            {{ empresa_form.observacao_prefeitura(class="form-control", id="observacao_prefeitura", placeholder="Observação", style="height: 100px; overflow-y: auto;") }}
+                            {{ empresa_form.observacao_prefeitura.label }}
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Sistemas e Consultorias -->
                 <div class="row mb-4">
                     <div class="col-12">
@@ -246,9 +269,13 @@
 </div>
 
 {% block scripts %}
+<script src="{{ url_for('static', filename='javascript/prefeituras.js') }}"></script>
+<script src="{{ url_for('static', filename='javascript/observacao.js') }}"></script>
 <script src="https://unpkg.com/imask"></script>
 <script>
 document.addEventListener("DOMContentLoaded", function () {
+    setupPrefeituras('links-prefeitura-container', 'add-prefeitura', 'links_prefeitura_json');
+    setupObservacao('add_obs_prefeitura', 'obs_prefeitura_container', 'observacao_prefeitura');
     // Máscara para CNPJ
     const cnpjField = document.querySelector('#cnpj');
     if (cnpjField) {

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -145,6 +145,51 @@
                     </div>
                 </div>
             </div>
+            <div class="row g-4 mt-2">
+                <div class="col-12">
+                    <div class="info-group">
+                        <h6 class="text-primary mb-3 border-bottom pb-2"><i class="bi bi-building me-2"></i>Acesso à Prefeitura</h6>
+                        {% if empresa.links_prefeitura %}
+                            <div class="row g-2 fw-semibold mb-1">
+                                <div class="col-md-3">Cidade</div>
+                                <div class="col-md-3">Link</div>
+                                <div class="col-md-3">Usuário</div>
+                                <div class="col-md-3">Senha</div>
+                            </div>
+                            {% for acesso in empresa.links_prefeitura %}
+                                <div class="row g-2 mb-2">
+                                    <div class="col-md-3">
+                                        <input type="text" class="form-control" value="{{ acesso.cidade or '' }}" readonly>
+                                    </div>
+                                    <div class="col-md-3">
+                                        {% if acesso.link %}
+                                            <a href="{{ acesso.link }}" target="_blank" rel="noopener noreferrer" class="form-control d-block text-primary text-decoration-underline text-truncate" title="{{ acesso.link }}">{{ acesso.link }}</a>
+                                        {% else %}
+                                            <input type="text" class="form-control" value="" readonly>
+                                        {% endif %}
+                                    </div>
+                                    <div class="col-md-3">
+                                        <input type="text" class="form-control" value="{{ acesso.usuario or '' }}" readonly>
+                                    </div>
+                                    <div class="col-md-3">
+                                        <input type="text" class="form-control" value="{{ acesso.senha or '' }}" readonly>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        {% else %}
+                            <div class="info-item"><span class="text-muted">Não informado</span></div>
+                        {% endif %}
+                        {% if empresa.observacao_prefeitura %}
+                        <div class="info-item mt-2">
+                            <label class="info-label">Observação</label>
+                            <div class="info-value">
+                                <textarea class="form-control form-control-sm" readonly style="height:80px">{{ empresa.observacao_prefeitura }}</textarea>
+                            </div>
+                        </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -206,53 +251,6 @@
                     </div>
                 </div>
 
-                <div class="row g-4 mt-2">
-                    <div class="col-12">
-                        <div class="info-group">
-                            <h6 class="text-dept-blue mb-3 border-bottom pb-2"><i class="bi bi-building me-2"></i>Acesso à Prefeitura</h6>
-                            {% if fiscal.links_prefeitura %}
-                                <div class="row g-2 fw-semibold mb-1">
-                                    <div class="col-md-3">Cidade</div>
-                                    <div class="col-md-3">Link</div>
-                                    <div class="col-md-3">Usuário</div>
-                                    <div class="col-md-3">Senha</div>
-                                </div>
-                                {% for acesso in fiscal.links_prefeitura %}
-                                    <div class="row g-2 mb-2">
-                                        <div class="col-md-3">
-                                            <input type="text" class="form-control" value="{{ acesso.cidade or '' }}" readonly>
-                                        </div>
-                                        <div class="col-md-3">
-                                            {% if acesso.link %}
-                                                <a href="{{ acesso.link }}" target="_blank" rel="noopener noreferrer"
-                                                   class="form-control d-block text-primary text-decoration-underline text-truncate"
-                                                   title="{{ acesso.link }}">{{ acesso.link }}</a>
-                                            {% else %}
-                                                <input type="text" class="form-control" value="" readonly>
-                                            {% endif %}
-                                        </div>
-                                        <div class="col-md-3">
-                                            <input type="text" class="form-control" value="{{ acesso.usuario or '' }}" readonly>
-                                        </div>
-                                        <div class="col-md-3">
-                                            <input type="text" class="form-control" value="{{ acesso.senha or '' }}" readonly>
-                                        </div>
-                                    </div>
-                                {% endfor %}
-                            {% else %}
-                                <div class="info-item"><span class="text-muted">Não informado</span></div>
-                            {% endif %}
-                            {% if fiscal.observacao_prefeitura %}
-                            <div class="info-item mt-2">
-                                <label class="info-label">Observação</label>
-                                <div class="info-value">
-                                    <textarea class="form-control form-control-sm" readonly style="height:80px">{{ fiscal.observacao_prefeitura }}</textarea>
-                                </div>
-                            </div>
-                            {% endif %}
-                        </div>
-                    </div>
-                </div>
 
                 <div class="row g-4 mt-2">
                     <div class="col-12">


### PR DESCRIPTION
## Summary
- restrict prefeitura access fields to companies and drop department-level references
- update department management and company views to pass correct prefeitura parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a7164145ac8330b15aca3e46787326

## Summary by Sourcery

Add municipality (Prefeitura) access management to company registration and views, migrating access fields from the department context to the company context.

New Features:
- Introduce company-level `links_prefeitura` and `observacao_prefeitura` fields in the Empresa model and form
- Add dynamic UI in company create/edit/view templates for managing multiple Prefeitura access entries and notes

Enhancements:
- Remove all department-level Prefeitura access handling, including model columns, forms, templates, and route logic
- Update company controllers to parse, validate, and store Prefeitura links JSON and observation data