### PR TITLE
Atualiza campos de acesso do cliente

### DIFF
--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -217,8 +217,7 @@ def cadastrar_empresa():
                 atividade_principal=form.atividade_principal.data,
                 sistemas_consultorias=form.sistemas_consultorias.data,
                 sistema_utilizado=form.sistema_utilizado.data,
-                links_prefeitura=links_prefeitura,
-                observacao_prefeitura=form.observacao_prefeitura.data
+                links_prefeitura=links_prefeitura
             )
             db.session.add(nova_empresa)
             db.session.commit()
@@ -287,7 +286,6 @@ def processar_dados_fiscal(request):
     forma_movimento = request.form.get('forma_movimento')
     observacao_movimento = request.form.get('observacao_movimento')
     observacao_importacao = request.form.get('observacao_importacao')
-    observacao_prefeitura = request.form.get('observacao_prefeitura')
     observacao_contato = request.form.get('observacao_contato')
     particularidades = request.form.get('particularidades')
     formas_importacao_json = request.form.get('formas_importacao_json', '[]')
@@ -311,7 +309,6 @@ def processar_dados_fiscal(request):
         'malote_coleta': malote_coleta,
         'observacao_movimento': observacao_movimento,
         'observacao_importacao': observacao_importacao,
-        'observacao_prefeitura': observacao_prefeitura,
         'observacao_contato': observacao_contato,
         'contatos': contatos,
         'particularidades_texto': particularidades
@@ -376,7 +373,6 @@ def editar_empresa(id):
         if empresa.regime_lancamento:
             empresa_form.regime_lancamento.data = empresa.regime_lancamento.value
         empresa_form.links_prefeitura_json.data = json.dumps(empresa.links_prefeitura or [])
-        empresa_form.observacao_prefeitura.data = empresa.observacao_prefeitura
 
     if request.method == 'POST':
         if empresa_form.validate():
@@ -387,7 +383,6 @@ def editar_empresa(id):
                 empresa.links_prefeitura = json.loads(empresa_form.links_prefeitura_json.data or '[]')
             except Exception:
                 empresa.links_prefeitura = []
-            empresa.observacao_prefeitura = empresa_form.observacao_prefeitura.data
             db.session.add(empresa)
             try:
                 db.session.commit()

--- a/app/forms.py
+++ b/app/forms.py
@@ -78,7 +78,6 @@ class EmpresaForm(FlaskForm):
     ], validators=[Optional()])
     sistema_utilizado = StringField('Sistema Utilizado', validators=[Optional()])
     links_prefeitura_json = HiddenField('Links Prefeitura', validators=[Optional()])
-    observacao_prefeitura = TextAreaField('Observação', validators=[Optional()])
     submit = SubmitField('Cadastrar Empresa')
 
 class EditUserForm(FlaskForm):

--- a/app/static/javascript/prefeituras.js
+++ b/app/static/javascript/prefeituras.js
@@ -15,11 +15,12 @@ function setupPrefeituras(containerId, addBtnId, hiddenInputId) {
       const row = document.createElement('div');
       row.className = 'row g-2 mb-2 prefeitura-item';
       row.innerHTML = `
-        <div class="col-md-3"><input type="text" class="form-control prefeitura-cidade" placeholder="Cidade" value="${p.cidade || ''}"></div>
+        <div class="col-md-3"><input type="text" class="form-control prefeitura-acesso" placeholder="Acesso" value="${p.acesso || ''}"></div>
         <div class="col-md-3"><input type="text" class="form-control prefeitura-link" placeholder="Link" value="${p.link || ''}"></div>
         <div class="col-md-2"><input type="text" class="form-control prefeitura-usuario" placeholder="Usuário" value="${p.usuario || ''}"></div>
         <div class="col-md-2"><input type="text" class="form-control prefeitura-senha" placeholder="Senha" value="${p.senha || ''}"></div>
         <div class="col-md-2 d-flex align-items-center"><button type="button" class="btn btn-danger btn-sm w-100 remove-prefeitura" data-idx="${idx}">Remover</button></div>
+        <div class="col-12 mt-2"><textarea class="form-control prefeitura-observacao" placeholder="Observação" rows="2">${p.observacao || ''}</textarea></div>
       `;
       container.appendChild(row);
     });
@@ -40,16 +41,17 @@ function setupPrefeituras(containerId, addBtnId, hiddenInputId) {
   function updateHidden() {
     const items = container.querySelectorAll('.prefeitura-item');
     prefeituras = Array.from(items).map(item => ({
-      cidade: item.querySelector('.prefeitura-cidade').value,
+      acesso: item.querySelector('.prefeitura-acesso').value,
       link: item.querySelector('.prefeitura-link').value,
       usuario: item.querySelector('.prefeitura-usuario').value,
       senha: item.querySelector('.prefeitura-senha').value,
+      observacao: item.querySelector('.prefeitura-observacao').value,
     }));
     hiddenInput.value = JSON.stringify(prefeituras);
   }
 
   addBtn.addEventListener('click', function () {
-    prefeituras.push({ cidade: '', link: '', usuario: '', senha: '' });
+    prefeituras.push({ acesso: '', link: '', usuario: '', senha: '', observacao: '' });
     render();
   });
 

--- a/app/templates/departamentos/cadastrar_fiscal.html
+++ b/app/templates/departamentos/cadastrar_fiscal.html
@@ -54,7 +54,7 @@
                 <div class="row mb-4">
                     <div class="col-12">
                         <h5 class="text-primary border-bottom pb-2 mb-3">
-                            <i class="bi bi-building me-2"></i>Acesso à Prefeitura
+                            <i class="bi bi-building me-2"></i>Acessos do Cliente
                         </h5>
                     </div>
                 </div>

--- a/app/templates/empresas/cadastrar.html
+++ b/app/templates/empresas/cadastrar.html
@@ -189,7 +189,7 @@
                 <div class="row mb-4">
                     <div class="col-12">
                         <h5 class="text-primary border-bottom pb-2 mb-3">
-                            <i class="bi bi-building me-2"></i>Acesso à Prefeitura
+                            <i class="bi bi-building me-2"></i>Acessos do Cliente
                         </h5>
                     </div>
                 </div>
@@ -201,11 +201,6 @@
                             <i class="bi bi-plus-circle"></i> Adicionar Link
                         </button>
                         {{ form.links_prefeitura_json(id='links_prefeitura_json') }}
-                        <button type="button" class="btn btn-outline-primary btn-sm mt-2" id="add_obs_prefeitura"><i class="bi bi-plus-circle"></i> Adicionar Observação</button>
-                        <div id="obs_prefeitura_container" class="form-floating mt-2" style="display:none;">
-                            {{ form.observacao_prefeitura(class="form-control", id="observacao_prefeitura", placeholder="Observação", style="height: 100px; overflow-y: auto;") }}
-                            {{ form.observacao_prefeitura.label }}
-                        </div>
                     </div>
                 </div>
 
@@ -290,7 +285,6 @@
 <script>
 document.addEventListener("DOMContentLoaded", function () {
     setupPrefeituras('links-prefeitura-container', 'add-prefeitura', 'links_prefeitura_json');
-    setupObservacao('add_obs_prefeitura', 'obs_prefeitura_container', 'observacao_prefeitura');
     // Auto-dismiss existing alerts
     const autoDismiss = (alertEl) => {
         setTimeout(() => {

--- a/app/templates/empresas/editar_empresa.html
+++ b/app/templates/empresas/editar_empresa.html
@@ -171,7 +171,7 @@
                 <div class="row mb-4">
                     <div class="col-12">
                         <h5 class="text-primary border-bottom pb-2 mb-3">
-                            <i class="bi bi-building me-2"></i>Acesso à Prefeitura
+                            <i class="bi bi-building me-2"></i>Acessos do Cliente
                         </h5>
                     </div>
                 </div>
@@ -183,11 +183,6 @@
                             <i class="bi bi-plus-circle"></i> Adicionar Link
                         </button>
                         {{ empresa_form.links_prefeitura_json(id='links_prefeitura_json') }}
-                        <button type="button" class="btn btn-outline-primary btn-sm mt-2" id="add_obs_prefeitura"><i class="bi bi-plus-circle"></i> Adicionar Observação</button>
-                        <div id="obs_prefeitura_container" class="form-floating mt-2" style="display:none;">
-                            {{ empresa_form.observacao_prefeitura(class="form-control", id="observacao_prefeitura", placeholder="Observação", style="height: 100px; overflow-y: auto;") }}
-                            {{ empresa_form.observacao_prefeitura.label }}
-                        </div>
                     </div>
                 </div>
 
@@ -275,7 +270,6 @@
 <script>
 document.addEventListener("DOMContentLoaded", function () {
     setupPrefeituras('links-prefeitura-container', 'add-prefeitura', 'links_prefeitura_json');
-    setupObservacao('add_obs_prefeitura', 'obs_prefeitura_container', 'observacao_prefeitura');
     // Máscara para CNPJ
     const cnpjField = document.querySelector('#cnpj');
     if (cnpjField) {

--- a/app/templates/empresas/visualizar.html
+++ b/app/templates/empresas/visualizar.html
@@ -148,10 +148,10 @@
             <div class="row g-4 mt-2">
                 <div class="col-12">
                     <div class="info-group">
-                        <h6 class="text-primary mb-3 border-bottom pb-2"><i class="bi bi-building me-2"></i>Acesso à Prefeitura</h6>
+                        <h6 class="text-primary mb-3 border-bottom pb-2"><i class="bi bi-building me-2"></i>Acessos do Cliente</h6>
                         {% if empresa.links_prefeitura %}
                             <div class="row g-2 fw-semibold mb-1">
-                                <div class="col-md-3">Cidade</div>
+                                <div class="col-md-3">Acesso</div>
                                 <div class="col-md-3">Link</div>
                                 <div class="col-md-3">Usuário</div>
                                 <div class="col-md-3">Senha</div>
@@ -159,7 +159,7 @@
                             {% for acesso in empresa.links_prefeitura %}
                                 <div class="row g-2 mb-2">
                                     <div class="col-md-3">
-                                        <input type="text" class="form-control" value="{{ acesso.cidade or '' }}" readonly>
+                                        <input type="text" class="form-control" value="{{ acesso.acesso or '' }}" readonly>
                                     </div>
                                     <div class="col-md-3">
                                         {% if acesso.link %}
@@ -174,18 +174,15 @@
                                     <div class="col-md-3">
                                         <input type="text" class="form-control" value="{{ acesso.senha or '' }}" readonly>
                                     </div>
+                                    {% if acesso.observacao %}
+                                    <div class="col-12 mt-2">
+                                        <textarea class="form-control form-control-sm" readonly style="height:80px">{{ acesso.observacao }}</textarea>
+                                    </div>
+                                    {% endif %}
                                 </div>
                             {% endfor %}
                         {% else %}
                             <div class="info-item"><span class="text-muted">Não informado</span></div>
-                        {% endif %}
-                        {% if empresa.observacao_prefeitura %}
-                        <div class="info-item mt-2">
-                            <label class="info-label">Observação</label>
-                            <div class="info-value">
-                                <textarea class="form-control form-control-sm" readonly style="height:80px">{{ empresa.observacao_prefeitura }}</textarea>
-                            </div>
-                        </div>
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Renomeia seção "Acesso à Prefeitura" para "Acessos do Cliente"
- Troca campo "Cidade" por "Acesso" e permite observação individual
- Remove observação geral da prefeitura do formulário

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a72fccf6a48330a65da13f2da50c17

## Summary by Sourcery

Update the client access section by renaming it, replacing the city field with a generic access field, removing the global observation field, and adding support for individual observations on each access entry

New Features:
- Allow individual observations for each client access entry

Enhancements:
- Rename the 'Acesso à Prefeitura' section to 'Acessos do Cliente' across all forms and views
- Replace the 'Cidade' field with a generic 'Acesso' field in the client access interface
- Update JavaScript to include per-access observation field and serialize it

Chores:
- Remove the global 'observacao_prefeitura' field from forms, templates, and controllers